### PR TITLE
Add missing command docs and update for multi-remote support

### DIFF
--- a/docs/guide/concepts.md
+++ b/docs/guide/concepts.md
@@ -162,14 +162,19 @@ Sync is managed automatically by DevBox:
 
 ## Remote Server
 
-The **remote server** stores your project backups and enables multi-machine workflows.
+The **remote server** stores your project backups and enables multi-machine workflows. DevBox supports **multiple remotes**, allowing you to organize projects across different servers (e.g., work server, personal server).
 
 ### Server Setup
 
-During `devbox init`, you configure:
+During `devbox init`, you configure your first remote. You can add more remotes later with `devbox remote add`.
 
+For each remote, you specify:
+
+- **Name** - A friendly identifier (e.g., "production", "personal")
 - **SSH Host** - The server to connect to
+- **SSH User** - Username for SSH connection
 - **Base Path** - Directory where projects are stored (e.g., `~/code`)
+- **SSH Key** - Optional path to SSH private key
 
 ### Remote Directory Structure
 
@@ -234,10 +239,6 @@ Taking over is safe when:
 DevBox stores its configuration in `~/.devbox/config.yaml`:
 
 ```yaml
-remote:
-  host: my-server          # SSH host name
-  base_path: ~/code        # Remote directory
-
 editor: cursor             # Default editor
 
 defaults:
@@ -247,9 +248,23 @@ defaults:
     - .git/*.lock
     # ... more patterns
 
+remotes:                   # Multiple remote servers
+  production:
+    host: prod.example.com
+    user: deploy
+    path: ~/code
+    key: ~/.ssh/id_ed25519
+  personal:
+    host: home-server
+    user: null             # Uses SSH config
+    path: ~/projects
+    key: null
+
 projects:
-  my-app: {}               # Registered projects
+  my-app:
+    remote: production     # Which remote this project belongs to
   other-project:
+    remote: personal
     editor: code           # Per-project overrides
 ```
 

--- a/docs/guide/index.md
+++ b/docs/guide/index.md
@@ -46,11 +46,12 @@ Unlike cloud-based development environments, DevBox runs containers on your mach
 
 ### Seamless Remote Backup
 
-Your code is automatically synced to a remote server:
+Your code is automatically synced to remote servers:
 
 - Never lose work due to local machine issues
 - Easy to switch between work laptop and home desktop
 - Built-in lock system prevents simultaneous edits from different machines
+- Multi-remote support for organizing projects across different servers
 
 ### Developer Experience
 

--- a/docs/guide/quick-start.md
+++ b/docs/guide/quick-start.md
@@ -277,9 +277,13 @@ devbox up my-project --rebuild
 | `devbox list` | List local projects |
 | `devbox push <path>` | Push local project to remote |
 | `devbox clone <project>` | Clone remote project locally |
+| `devbox new` | Create new project on remote |
 | `devbox up [project]` | Start development container |
 | `devbox down [project]` | Stop development container |
+| `devbox shell <project>` | Access shell inside container |
 | `devbox status [project]` | Show project status |
+| `devbox remote <subcommand>` | Manage remote servers |
+| `devbox config` | View/modify configuration |
 | `devbox editor` | Change default editor |
 | `devbox rm <project>` | Remove local project |
 

--- a/docs/reference/config.md
+++ b/docs/reference/config.md
@@ -1,0 +1,127 @@
+# devbox config
+
+View and modify DevBox configuration.
+
+## Usage
+
+```bash
+devbox config [subcommand] [options]
+```
+
+## Subcommands
+
+| Subcommand | Description |
+|------------|-------------|
+| (none) | Display current configuration |
+| `set <key> <value>` | Set a configuration value |
+
+## Options
+
+| Option | Description |
+|--------|-------------|
+| `--validate` | Test SSH connection to all configured remotes |
+
+## Description
+
+The `config` command provides ways to view and modify your DevBox configuration. It shows your configured remotes and global settings.
+
+### Display Configuration
+
+Running `devbox config` without arguments shows:
+
+```
+─── Remotes: ───
+
+  production  deploy@prod.example.com:~/code
+  personal    me@home-server:~/projects
+
+─── Settings: ───
+
+  editor: cursor
+```
+
+### Set Configuration Values
+
+Currently supported configuration keys:
+
+| Key | Description | Example Values |
+|-----|-------------|----------------|
+| `editor` | Default editor command | `cursor`, `code`, `vim`, `nvim`, `zed` |
+
+### Validate Configuration
+
+The `--validate` flag tests SSH connections to all remotes and shows project counts:
+
+```bash
+devbox config --validate
+```
+
+Output:
+```
+─── Testing remotes... ───
+
+  ✓ production - connected (5 projects)
+  ✓ personal - connected (3 projects)
+
+All remotes connected successfully.
+```
+
+If a connection fails:
+```
+  ✓ production - connected (5 projects)
+  ✗ personal - failed
+
+Some remotes failed to connect.
+```
+
+## Examples
+
+```bash
+# Show current configuration
+devbox config
+
+# Test all remote connections
+devbox config --validate
+
+# Change default editor to VS Code
+devbox config set editor code
+
+# Change default editor to Vim
+devbox config set editor vim
+
+# Change default editor to Cursor
+devbox config set editor cursor
+```
+
+### Workflow Example
+
+```bash
+# Check current setup
+devbox config
+
+# Verify all remotes are accessible
+devbox config --validate
+
+# Switch editor preference
+devbox config set editor code
+```
+
+## Configuration File
+
+The configuration is stored in `~/.devbox/config.yaml`. While `devbox config set` handles common changes, you can also edit the file directly for advanced configuration.
+
+For full configuration file documentation, see [Configuration Reference](/reference/configuration).
+
+## Exit Codes
+
+| Code | Meaning |
+|------|---------|
+| 0 | Success |
+| 1 | Error (no config, unknown key, validation failed) |
+
+## See Also
+
+- [Configuration Reference](/reference/configuration) - Full config file format
+- [devbox remote](/reference/remote) - Manage remote servers
+- [devbox editor](/reference/editor) - Interactive editor selection
+- [devbox init](/reference/init) - Initial setup wizard

--- a/docs/reference/index.md
+++ b/docs/reference/index.md
@@ -9,11 +9,15 @@ DevBox provides a set of commands for managing your local-first development envi
 | [`devbox init`](/reference/init) | Interactive setup wizard |
 | [`devbox up`](/reference/up) | Start a development container |
 | [`devbox down`](/reference/down) | Stop a development container |
+| [`devbox shell`](/reference/shell) | Access shell inside container |
 | [`devbox clone`](/reference/clone) | Clone remote project locally |
 | [`devbox push`](/reference/push) | Push local project to remote |
+| [`devbox new`](/reference/new) | Create new project on remote |
 | [`devbox browse`](/reference/browse) | List projects on remote server |
 | [`devbox list`](/reference/list) | List local projects |
 | [`devbox status`](/reference/status) | Show project status |
+| [`devbox remote`](/reference/remote) | Manage remote servers |
+| [`devbox config`](/reference/config) | View/modify configuration |
 | [`devbox editor`](/reference/editor) | Change default editor |
 | [`devbox rm`](/reference/rm) | Remove project locally (keeps remote) |
 
@@ -34,8 +38,33 @@ All commands support these global options:
 # Initial setup
 devbox init
 
+# View configuration
+devbox config
+
+# Test remote connections
+devbox config --validate
+
 # Change default editor
 devbox editor
+
+# Or via config
+devbox config set editor vim
+```
+
+### Managing Remote Servers
+
+```bash
+# Add a new remote
+devbox remote add myserver user@host:~/code
+
+# List configured remotes
+devbox remote list
+
+# Remove a remote
+devbox remote remove myserver
+
+# Rename a remote
+devbox remote rename myserver production
 ```
 
 ### Working with Projects
@@ -46,6 +75,12 @@ devbox up my-project
 
 # Stop a project
 devbox down my-project
+
+# Access shell inside container
+devbox shell my-project
+
+# Run a command in container
+devbox shell my-project -c "npm test"
 
 # Check project status
 devbox status my-project
@@ -62,6 +97,9 @@ devbox clone my-project
 
 # Push a local project to remote
 devbox push ./my-project
+
+# Create a new project on remote
+devbox new
 ```
 
 ### Cleanup

--- a/docs/reference/init.md
+++ b/docs/reference/init.md
@@ -34,8 +34,11 @@ If DevBox is already configured, you'll be asked whether to reconfigure.
 
 ### Remote Configuration
 
+The wizard configures your first remote server. You can add more remotes later with `devbox remote add`.
+
 The wizard allows you to:
 
+- Enter a name for the remote (e.g., "production", "personal")
 - Select an existing SSH host from your `~/.ssh/config`
 - Add a new server with hostname, username, and SSH key
 - Test the SSH connection
@@ -73,6 +76,7 @@ Installing mutagen...
   Mutagen installed
 
 Configure remote server
+? Remote name: production
 ? Select SSH host: my-server (192.168.1.100)
   SSH connection successful
 
@@ -92,19 +96,22 @@ Next steps:
   Push a local project: devbox push ./my-project
   Clone from remote: devbox clone <project-name>
   Browse remote projects: devbox browse
+  Add another remote: devbox remote add
 ```
 
 ## Configuration File
 
 After running `init`, DevBox creates a configuration file at `~/.devbox/config.yaml` containing:
 
-- Remote server host and base path
+- Remote server configurations (supports multiple remotes)
 - Default editor
 - Sync settings and ignore patterns
-- Registered projects
+- Registered projects with remote associations
 
 ## See Also
 
+- [devbox remote](/reference/remote) - Add more remote servers
+- [devbox config](/reference/config) - View and modify configuration
 - [devbox editor](/reference/editor) - Change the default editor later
 - [devbox browse](/reference/browse) - View projects on remote server
 - [devbox push](/reference/push) - Push a local project to remote

--- a/docs/reference/new.md
+++ b/docs/reference/new.md
@@ -1,0 +1,175 @@
+# devbox new
+
+Create a new project on the remote server.
+
+## Usage
+
+```bash
+devbox new
+```
+
+## Arguments
+
+This command takes no arguments. It runs interactively.
+
+## Options
+
+This command has no options. All configuration is done through interactive prompts.
+
+## Description
+
+The `new` command creates a new project directly on your remote server. This is useful when you want to start fresh rather than pushing an existing local project.
+
+The command walks you through:
+
+1. **Remote Selection** - Choose which remote server to create the project on
+2. **Project Name** - Enter a valid project name
+3. **Project Type** - Choose between empty project or template
+4. **Template Selection** - If using a template, choose from built-in or custom
+5. **Clone Option** - Optionally clone the new project locally
+
+### Project Naming Rules
+
+Project names must:
+- Contain only letters, numbers, hyphens, and underscores
+- Not start with a hyphen or underscore
+- Not already exist on the selected remote
+
+### Project Types
+
+**Empty Project:**
+Creates a minimal project directory with just a `devcontainer.json`:
+
+```
+my-project/
+└── .devcontainer/
+    └── devcontainer.json
+```
+
+**From Template:**
+Clones a git repository to create the project. You can:
+- Use built-in starter templates (Node.js, Bun, Python, Go)
+- Use custom templates from your config
+- Enter any git URL
+
+## Examples
+
+```bash
+# Start the interactive wizard
+devbox new
+```
+
+### Example Session
+
+```
+─── Create a new project ───
+
+? Select remote: production
+? Project name: my-new-api
+  Checking remote... Name available
+? How would you like to create this project?
+  > Empty project (with devcontainer.json)
+    From a template
+
+Creating project on remote... done
+
+? Clone this project locally now? (Y/n)
+```
+
+### Creating from Template
+
+```
+? How would you like to create this project?
+    Empty project (with devcontainer.json)
+  > From a template
+
+? Select a template:
+  ──── Built-in ────
+    Node.js Starter
+    Bun Starter
+    Python Starter
+    Go Starter
+  ──── Custom ────
+    my-company-template
+  ────────────────
+    Enter git URL...
+
+Cloning template to remote... done
+```
+
+### Using Custom Git URL
+
+```
+? Select a template: Enter git URL...
+? Git repository URL: https://github.com/org/template-repo.git
+? Git history:
+  > Start fresh (recommended)
+    Keep original history
+
+Cloning template to remote... done
+```
+
+## Built-in Templates
+
+| Template | Description |
+|----------|-------------|
+| Node.js Starter | Node.js 20 with npm, ESLint, devcontainer |
+| Bun Starter | Bun runtime with TypeScript |
+| Python Starter | Python 3.12 with pip, venv |
+| Go Starter | Go 1.22 with standard tooling |
+
+All templates include:
+- Proper devcontainer.json configuration
+- Docker-outside-of-Docker support
+- SSH passthrough for git operations
+- Language-specific VS Code extensions
+
+## Custom Templates
+
+You can configure custom templates in `~/.devbox/config.yaml`:
+
+```yaml
+templates:
+  my-company-template: https://github.com/myorg/template.git
+  react-starter: https://github.com/myorg/react-template.git
+```
+
+These appear in the template selection menu under "Custom".
+
+## Git History Options
+
+When using a custom git URL:
+
+**Start fresh (recommended):**
+- Removes the original `.git` directory
+- Initializes a new git repository
+- Your project starts with a clean history
+
+**Keep original history:**
+- Preserves the template's full git history
+- Useful for forking an existing project
+
+## After Creation
+
+After creating a project, you're prompted to clone it locally:
+
+```
+? Clone this project locally now? (Y/n)
+```
+
+- **Yes** - Runs `devbox clone <project>` to sync locally
+- **No** - Project exists only on remote; clone later with `devbox clone`
+
+## Exit Codes
+
+| Code | Meaning |
+|------|---------|
+| 0 | Success |
+| 1 | Error (project exists, clone failed, no config) |
+
+## See Also
+
+- [devbox clone](/reference/clone) - Clone project from remote
+- [devbox push](/reference/push) - Push existing project to remote
+- [devbox browse](/reference/browse) - List projects on remote
+- [devbox remote](/reference/remote) - Manage remote servers

--- a/docs/reference/remote.md
+++ b/docs/reference/remote.md
@@ -1,0 +1,188 @@
+# devbox remote
+
+Manage remote server configurations.
+
+## Usage
+
+```bash
+devbox remote <subcommand> [options]
+```
+
+## Subcommands
+
+| Subcommand | Description |
+|------------|-------------|
+| `add [name] [user@host:path]` | Add a new remote server |
+| `list` | List all configured remotes |
+| `remove <name>` | Remove a remote server |
+| `rename <old> <new>` | Rename a remote server |
+
+## Description
+
+The `remote` command manages connections to remote servers where your projects are stored and synced. DevBox supports multiple remote servers, allowing you to organize projects across different machines (e.g., work server, personal server, client servers).
+
+### Multi-Remote Support
+
+Each project is associated with exactly one remote. When you have multiple remotes configured, commands like `push`, `clone`, and `browse` will prompt you to select which remote to use.
+
+## Subcommand Details
+
+### `devbox remote add`
+
+Add a new remote server configuration.
+
+**Interactive mode:**
+```bash
+devbox remote add
+```
+
+Walks you through:
+1. Remote name (identifier)
+2. Server hostname or IP
+3. SSH username
+4. Remote projects directory
+5. SSH key selection
+6. Connection test
+7. Directory creation (if needed)
+
+**Direct mode:**
+```bash
+devbox remote add <name> <user@host:path> [--key <path>]
+```
+
+| Option | Description |
+|--------|-------------|
+| `-k, --key <path>` | Path to SSH private key |
+
+### `devbox remote list`
+
+Display all configured remotes.
+
+```bash
+devbox remote list
+```
+
+Output:
+```
+  production  deploy@prod.example.com:~/code
+  personal    noor@home-server:~/projects
+```
+
+### `devbox remote remove`
+
+Remove a remote configuration.
+
+```bash
+devbox remote remove <name>
+```
+
+If projects are associated with the remote, you'll be warned:
+
+```
+The following projects use this remote:
+    my-app
+    backend-api
+Remove remote anyway? (projects will need to be reassigned) (y/N)
+```
+
+### `devbox remote rename`
+
+Rename a remote and update all project references.
+
+```bash
+devbox remote rename <old-name> <new-name>
+```
+
+This automatically updates all projects that reference the old name.
+
+## Examples
+
+```bash
+# Interactive wizard to add a remote
+devbox remote add
+
+# Add remote directly
+devbox remote add myserver root@192.168.1.100:~/code
+
+# Add remote with specific SSH key
+devbox remote add myserver root@host:~/code --key ~/.ssh/id_ed25519
+
+# List all remotes
+devbox remote list
+
+# Remove a remote
+devbox remote remove myserver
+
+# Rename a remote
+devbox remote rename myserver production
+```
+
+### Typical Multi-Remote Setup
+
+```bash
+# Add work server
+devbox remote add work deploy@work.example.com:~/projects
+
+# Add personal server
+devbox remote add personal me@home-server:~/code
+
+# Push project to specific remote
+devbox push ./my-project
+# ? Select remote: work
+
+# Clone from specific remote
+devbox clone my-project
+# ? Select remote: personal
+```
+
+## Remote Entry Format
+
+Each remote is stored in the configuration with these fields:
+
+| Field | Description |
+|-------|-------------|
+| `host` | SSH hostname or IP address |
+| `user` | SSH username (or null to use SSH config default) |
+| `path` | Base directory for projects on the remote |
+| `key` | Path to SSH private key (or null to use SSH config default) |
+
+Example in `~/.devbox/config.yaml`:
+
+```yaml
+remotes:
+  production:
+    host: prod.example.com
+    user: deploy
+    path: ~/code
+    key: ~/.ssh/id_ed25519
+
+  personal:
+    host: home-server
+    user: null          # Uses SSH config
+    path: ~/projects
+    key: null           # Uses SSH config
+```
+
+## SSH Key Setup
+
+When adding a remote, if the connection test fails, you'll be offered to copy your SSH key:
+
+```
+SSH connection failed
+Copy SSH key to server? (requires password) (Y/n)
+```
+
+This runs `ssh-copy-id` to install your public key on the server.
+
+## Exit Codes
+
+| Code | Meaning |
+|------|---------|
+| 0 | Success |
+| 1 | Error (invalid format, remote not found, connection failed) |
+
+## See Also
+
+- [devbox init](/reference/init) - Initial setup (creates first remote)
+- [devbox config](/reference/config) - View/modify configuration
+- [Configuration Reference](/reference/configuration) - Full config file format

--- a/docs/reference/shell.md
+++ b/docs/reference/shell.md
@@ -1,0 +1,117 @@
+# devbox shell
+
+Access an interactive shell inside a running container.
+
+## Usage
+
+```bash
+devbox shell <project> [options]
+```
+
+## Arguments
+
+| Argument | Description |
+|----------|-------------|
+| `<project>` | Name of the project to access (required) |
+
+## Options
+
+| Option | Description |
+|--------|-------------|
+| `-c, --command <cmd>` | Run a single command and exit instead of interactive shell |
+
+## Description
+
+The `shell` command provides interactive shell access to a running development container. It performs the following steps:
+
+1. **Configuration Check** - Verifies DevBox is configured
+2. **Project Verification** - Checks the project exists locally
+3. **Container Status** - Checks if container is running
+4. **Auto-Start** - Offers to start the container if not running
+5. **Shell Attach** - Opens an interactive shell inside the container
+
+### Interactive Mode
+
+By default, `devbox shell` opens an interactive `/bin/sh` session inside the container. The working directory is set to the workspace folder defined in `devcontainer.json`.
+
+### Command Mode
+
+With the `-c` flag, you can run a single command and exit. The exit code from the command is propagated back to your shell.
+
+### Container Auto-Start
+
+If the container is not running, you'll be prompted:
+
+```
+Container is not running. Start it now? (Y/n)
+```
+
+Choosing **yes** runs `devbox up` with `--no-prompt` to start the container before attaching to the shell.
+
+## Examples
+
+```bash
+# Open interactive shell
+devbox shell my-project
+
+# Run a single command
+devbox shell my-project -c "npm run build"
+
+# Check Node version inside container
+devbox shell my-project -c "node --version"
+
+# Run tests inside container
+devbox shell my-project -c "npm test"
+
+# Interactive shell for debugging
+devbox shell my-project
+# Then inside: ls -la, cat package.json, etc.
+```
+
+### Workflow Example
+
+```bash
+# Start a project
+devbox up my-project
+
+# Open shell to run commands
+devbox shell my-project
+# Inside container:
+# $ npm install
+# $ npm run dev
+# Press Ctrl+D to exit
+
+# Or run commands directly
+devbox shell my-project -c "npm install && npm run build"
+```
+
+### Difference from `devbox up --attach`
+
+| Command | Behavior |
+|---------|----------|
+| `devbox up --attach` | Starts container + acquires lock + attaches shell |
+| `devbox shell` | Just attaches to existing/started container |
+
+Use `devbox shell` when:
+- Container is already running
+- You just want shell access without the full startup flow
+- You want to run a quick command
+
+Use `devbox up --attach` when:
+- Starting a work session
+- You need the lock acquired
+- Container might not be running
+
+## Exit Codes
+
+| Code | Meaning |
+|------|---------|
+| 0 | Success (interactive mode exited cleanly) |
+| 1 | Error (project not found, container failed to start) |
+| * | Command exit code (when using `-c` flag) |
+
+## See Also
+
+- [devbox up](/reference/up) - Start the container
+- [devbox down](/reference/down) - Stop the container
+- [devbox status](/reference/status) - Check container status


### PR DESCRIPTION
- Add reference docs for shell, remote, new, and config commands
- Update configuration.md to document multi-remote format (remotes map)
- Update concepts.md with multi-remote architecture
- Update reference index and quick-start with all commands
- Update init.md to reference multi-remote and remote add command
- Update guide/index.md to mention multi-remote support