### PR TITLE
fix: suppress biome warnings for devcontainer placeholders

### DIFF
--- a/src/lib/templates.ts
+++ b/src/lib/templates.ts
@@ -233,8 +233,10 @@ export function scaffoldTemplate(name: string): string {
 	const config = {
 		name,
 		image: "mcr.microsoft.com/devcontainers/base:debian",
+		// biome-ignore lint/suspicious/noTemplateCurlyInString: devcontainer variable placeholders
 		workspaceFolder: "/workspaces/${localWorkspaceFolderBasename}",
 		workspaceMount:
+			// biome-ignore lint/suspicious/noTemplateCurlyInString: devcontainer variable placeholders
 			"source=${localWorkspaceFolder},target=/workspaces/${localWorkspaceFolderBasename},type=bind,consistency=cached",
 		postCreateCommand: "",
 		postStartCommand: "",


### PR DESCRIPTION
Suppress biome lint warnings for devcontainer variable placeholders in `src/lib/templates.ts`.

The `${...}` syntax in these strings is interpreted by devcontainer tooling, not JavaScript. Added `biome-ignore` comments to silence the false positive warnings.

All pre-commit checks pass (lint, typecheck, tests).