### PR TITLE
fix: disable circular scrolling in template picker

### DIFF
--- a/src/lib/templates.ts
+++ b/src/lib/templates.ts
@@ -350,6 +350,7 @@ export async function selectTemplate(): Promise<TemplateSelection | null> {
 			const choice = await select({
 				message: "Select a template:",
 				choices,
+				loop: false,
 			});
 
 			if (choice === "git-url") {


### PR DESCRIPTION
Fixes infinite scroll behavior in the template selection prompt. Added `loop: false` option to the `@inquirer/prompts` select() function so the list stops at the bottom instead of wrapping around.