### PR TITLE
docs: clarify Cloud Storage Backend scope

### DIFF
--- a/plans/IMPLEMENTATION.md
+++ b/plans/IMPLEMENTATION.md
@@ -188,7 +188,7 @@ bash/zsh/fish completion scripts for all commands and options.
 ## Future Features — Exploratory
 
 - [ ] **Custom Sync Engine:** Replace Mutagen with a purpose-built sync solution
-- [ ] **Cloud Storage Backend:** S3/GCS/B2 as alternative to SSH remotes
+- [ ] **Cloud Storage Backend:** Remote-to-S3 backups via rclone (not real-time sync — Mutagen requires an agent on both sides, which rules out object storage as a sync target)
 - [ ] **Metrics/Analytics:** Local-only usage metrics for debugging and optimization
 
 ---


### PR DESCRIPTION
## Summary

Refined the Cloud Storage Backend exploratory feature to reflect a more realistic approach: remote-to-S3 backups via rclone rather than real-time sync. Mutagen requires an agent on both sides of the sync, which is incompatible with object storage backends.

## Notes

This clarification came from investigating whether Mutagen could support S3-compatible and SFTP backends. The research confirmed that Mutagen's architecture (agent-based sync) cannot work with object storage, making rclone-based backups a better fit for future cloud integration.