### PR TITLE
Add LLMs.txt support and SEO improvements

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -1,9 +1,19 @@
 import { defineConfig } from 'vitepress'
+import llmstxt from 'vitepress-plugin-llms'
 import { commands } from './commands'
 
 export default defineConfig({
   title: 'DevBox',
   description: 'Development environment management CLI',
+  srcExclude: ['**/architecture/**'],
+
+  sitemap: {
+    hostname: 'https://devbox.noorxlabs.com'
+  },
+
+  vite: {
+    plugins: [llmstxt()]
+  },
 
   head: [
     ['link', { rel: 'icon', type: 'image/svg+xml', href: '/devbox-logo-grey.svg' }],
@@ -23,7 +33,6 @@ export default defineConfig({
     nav: [
       { text: 'Guide', link: '/guide/', activeMatch: '/guide/' },
       { text: 'Reference', link: '/reference/', activeMatch: '/reference/' },
-      { text: 'Architecture', link: '/architecture/', activeMatch: '/architecture/' },
     ],
 
     sidebar: {
@@ -57,6 +66,12 @@ export default defineConfig({
             { text: 'Troubleshooting', link: '/guide/troubleshooting' },
           ],
         },
+        {
+          text: 'Resources',
+          items: [
+            { text: 'LLMs.txt', link: '/llms-full.txt' },
+          ],
+        },
       ],
 
       '/reference/': [
@@ -75,15 +90,10 @@ export default defineConfig({
             { text: 'Hooks', link: '/reference/hooks' },
           ],
         },
-      ],
-
-      '/architecture/': [
         {
-          text: 'Architecture',
+          text: 'Resources',
           items: [
-            { text: 'Overview', link: '/architecture/' },
-            { text: 'Codebase Guide', link: '/architecture/codebase' },
-            { text: 'Design Decisions', link: '/architecture/design-decisions' },
+            { text: 'LLMs.txt', link: '/llms-full.txt' },
           ],
         },
       ],

--- a/docs/.vitepress/theme/index.ts
+++ b/docs/.vitepress/theme/index.ts
@@ -4,9 +4,4 @@ import './style.css'
 
 export default {
   extends: DefaultTheme,
-  // Add custom components or layout overrides here
-  // enhanceApp({ app, router, siteData }) {
-  //   // Register global components
-  //   // app.component('MyComponent', MyComponent)
-  // },
 } satisfies Theme

--- a/docs/architecture/design-decisions.md
+++ b/docs/architecture/design-decisions.md
@@ -190,7 +190,7 @@ Lock acquisition uses shell's noclobber mode (`set -C`) for atomic test-and-set.
 {
   "machine": "macbook-pro",
   "user": "noor",
-  "timestamp": "2024-01-15T10:30:00Z",
+  "timestamp": "2026-02-03T10:30:00Z",
   "pid": 12345
 }
 ```

--- a/docs/bunfig.toml
+++ b/docs/bunfig.toml
@@ -1,0 +1,4 @@
+telemetry = false
+
+[install]
+exact = true

--- a/docs/guide/concepts.md
+++ b/docs/guide/concepts.md
@@ -288,7 +288,7 @@ Lock file format (stored as JSON):
 {
   "machine": "my-laptop",
   "user": "developer",
-  "timestamp": "2024-01-15T10:30:00Z",
+  "timestamp": "2026-02-03T10:30:00Z",
   "pid": 12345
 }
 ```
@@ -314,7 +314,7 @@ If the atomic creation fails (file already exists), DevBox checks ownership:
 If another machine holds the lock:
 
 ```
-Project locked by 'work-laptop' since 2024-01-15T08:00:00Z
+Project locked by 'work-laptop' since 2026-02-03T08:00:00Z
 Take over lock anyway? (y/N)
 ```
 

--- a/docs/guide/quick-start.md
+++ b/docs/guide/quick-start.md
@@ -196,7 +196,7 @@ Lock
   Status:     locked (this machine)
   Machine:    my-laptop
   User:       me
-  Timestamp:  2024-01-15T10:30:00Z
+  Timestamp:  2026-02-03T10:30:00Z
   PID:        12345
 
 Disk Usage

--- a/docs/guide/shell-integration.md
+++ b/docs/guide/shell-integration.md
@@ -114,8 +114,8 @@ cat ~/.devbox/logs/auto-up.log
 Example output:
 
 ```
-[2024-01-15T10:30:00.000Z] [my-project] Auto-starting container...
-[2024-01-15T10:30:05.000Z] [my-project] Container started successfully
+[2026-02-03T10:30:00.000Z] [my-project] Auto-starting container...
+[2026-02-03T10:30:05.000Z] [my-project] Container started successfully
 ```
 
 ### Verify the Hook Is Active

--- a/docs/guide/workflows/daily-development.md
+++ b/docs/guide/workflows/daily-development.md
@@ -129,7 +129,7 @@ Lock
   Status:     locked (this machine)
   Machine:    macbook-pro
   User:       john
-  Timestamp:  2024-01-15T10:30:00Z
+  Timestamp:  2026-02-03T10:30:00Z
 
 Disk Usage
   Local:      245M
@@ -349,7 +349,7 @@ Locks prevent two machines from editing the same project simultaneously. When yo
 ### Lock Conflict Resolution
 
 ```
-Project locked by 'work-laptop' since 2024-01-15T10:30:00Z
+Project locked by 'work-laptop' since 2026-02-03T10:30:00Z
 ? Take over lock anyway? (y/N)
 ```
 

--- a/docs/guide/workflows/team-sharing.md
+++ b/docs/guide/workflows/team-sharing.md
@@ -107,7 +107,7 @@ When Alice runs `devbox up backend-api`:
    {
      "machine": "alices-macbook",
      "user": "alice",
-     "timestamp": "2024-01-15T09:00:00Z",
+     "timestamp": "2026-02-03T09:00:00Z",
      "pid": 12345
    }
    ```
@@ -118,7 +118,7 @@ When Alice runs `devbox up backend-api`:
 If Bob runs `devbox up backend-api` while Alice has the lock:
 
 ```
-Project locked by 'alices-macbook' since 2024-01-15T09:00:00Z
+Project locked by 'alices-macbook' since 2026-02-03T09:00:00Z
 ? Take over lock anyway? (y/N)
 ```
 
@@ -163,7 +163,7 @@ Lock
   Status:     locked (alices-macbook)
   Machine:    alices-macbook
   User:       alice
-  Timestamp:  2024-01-15T09:00:00Z
+  Timestamp:  2026-02-03T09:00:00Z
 ```
 
 ### Quick Status Check
@@ -191,7 +191,7 @@ devbox locks
 Locks on team-server:
 
   PROJECT                         STATUS                     SINCE
-  backend-api                     locked (alices-macbook)    2024-01-15T09:00:00Z
+  backend-api                     locked (alices-macbook)    2026-02-03T09:00:00Z
   frontend-app                    unlocked
 ```
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -27,3 +27,7 @@ features:
     title: Container-Based
     details: Leverage Docker containers for consistent, isolated, and reproducible environments
 ---
+
+<div style="text-align: center; margin-top: 2rem; padding: 1rem; opacity: 0.7;">
+  <a href="/llms-full.txt" style="color: var(--vp-c-text-2);">LLMs.txt</a>
+</div>

--- a/docs/package.json
+++ b/docs/package.json
@@ -9,5 +9,8 @@
   },
   "dependencies": {
     "vitepress": "1.6.4"
+  },
+  "devDependencies": {
+    "vitepress-plugin-llms": "1.11.0"
   }
 }

--- a/docs/public/robots.txt
+++ b/docs/public/robots.txt
@@ -1,0 +1,4 @@
+User-agent: *
+Allow: /
+
+Sitemap: https://devbox.noorxlabs.com/sitemap.xml

--- a/docs/reference/locks.md
+++ b/docs/reference/locks.md
@@ -38,8 +38,8 @@ Projects are displayed in a table sorted with locked projects first:
 Locks on my-server:
 
   PROJECT                         STATUS                     SINCE
-  backend-api                     locked (alices-macbook)    2024-01-15T09:00:00Z
-  frontend-app                    locked (you)               2024-01-15T10:30:00Z
+  backend-api                     locked (alices-macbook)    2026-02-03T09:00:00Z
+  frontend-app                    locked (you)               2026-02-03T10:30:00Z
   data-service                    unlocked
 ```
 
@@ -65,7 +65,7 @@ devbox locks
 # Locks on my-server:
 #
 #   PROJECT                         STATUS                     SINCE
-#   backend-api                     locked (alices-macbook)    2024-01-15T09:00:00Z
+#   backend-api                     locked (alices-macbook)    2026-02-03T09:00:00Z
 #   frontend-app                    unlocked
 ```
 


### PR DESCRIPTION
Add LLMs.txt generation and SEO enhancements to the documentation site.

**Changes:**
- Integrate vitepress-plugin-llms for LLMs.txt auto-generation
- Configure sitemap with devbox.noorxlabs.com hostname
- Add robots.txt with sitemap reference
- Move Architecture section from public to internal-only (excluded via srcExclude)
- Add Resources section to sidebar with LLMs.txt links
- Update documentation examples with current timestamps

Reverted the client-side copyright year logic back to build-time rendering for simplicity.