### PR TITLE
docs: improve installation guide with direct download options

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -60,15 +60,24 @@ jobs:
         uses: softprops/action-gh-release@v2
         with:
           files: |
+            devbox-darwin-arm64
+            devbox-darwin-x64
+            devbox-linux-x64
+            devbox-linux-arm64
             devbox-darwin-arm64.tar.gz
             devbox-darwin-x64.tar.gz
             devbox-linux-x64.tar.gz
             devbox-linux-arm64.tar.gz
+            checksums.txt
           body_path: release-notes.md
 
       - name: Compute SHA256 hashes
         id: sha
         run: |
+          # Generate checksums.txt for users (both raw binaries and tarballs)
+          shasum -a 256 devbox-darwin-arm64 devbox-darwin-x64 devbox-linux-x64 devbox-linux-arm64 \
+            devbox-darwin-arm64.tar.gz devbox-darwin-x64.tar.gz devbox-linux-x64.tar.gz devbox-linux-arm64.tar.gz > checksums.txt
+          # Output tarball hashes for Homebrew formula
           echo "darwin_arm64=$(shasum -a 256 devbox-darwin-arm64.tar.gz | cut -d' ' -f1)" >> $GITHUB_OUTPUT
           echo "darwin_x64=$(shasum -a 256 devbox-darwin-x64.tar.gz | cut -d' ' -f1)" >> $GITHUB_OUTPUT
           echo "linux_x64=$(shasum -a 256 devbox-linux-x64.tar.gz | cut -d' ' -f1)" >> $GITHUB_OUTPUT

--- a/docs/guide/installation.md
+++ b/docs/guide/installation.md
@@ -13,7 +13,7 @@ DevBox requires:
 | SSH | - | Remote server connection |
 
 ::: tip Note
-The devcontainer CLI requires Node.js, but on macOS with Homebrew this is handled automatically.
+The devcontainer CLI requires Node.js. On macOS with Homebrew this is handled automatically; otherwise you'll need to install Node.js separately.
 :::
 
 ### Installing Prerequisites
@@ -26,6 +26,18 @@ brew install --cask docker
 
 # Install devcontainer CLI (includes Node.js automatically)
 brew install devcontainer
+```
+
+```bash [macOS (Direct Download)]
+# 1. Install Docker Desktop
+#    Download from: https://docs.docker.com/desktop/install/mac-install/
+#    Choose the version for your chip (Apple Silicon or Intel)
+
+# 2. Install Node.js (required for devcontainer CLI)
+#    Download LTS version from: https://nodejs.org/
+
+# 3. Install devcontainer CLI
+npm install -g @devcontainers/cli
 ```
 
 ```bash [Linux (Ubuntu/Debian)]
@@ -87,19 +99,14 @@ brew tap NoorXLabs/homebrew-tap
 brew install devbox
 ```
 
+```bash [macOS (Direct Download)]
+# Install with one command (auto-detects architecture)
+curl -fsSL https://install.noorxlabs.com/devbox | bash
+```
+
 ```bash [Linux / WSL]
-# Download the latest release for your platform
-# from https://github.com/NoorXLabs/DevBox/releases
-
-# For x64:
-curl -L -o devbox https://github.com/NoorXLabs/DevBox/releases/latest/download/devbox-linux-x64
-chmod +x devbox
-sudo mv devbox /usr/local/bin/
-
-# For ARM64:
-curl -L -o devbox https://github.com/NoorXLabs/DevBox/releases/latest/download/devbox-linux-arm64
-chmod +x devbox
-sudo mv devbox /usr/local/bin/
+# Install with one command (auto-detects architecture)
+curl -fsSL https://install.noorxlabs.com/devbox | bash
 ```
 
 ```bash [From Source]
@@ -233,9 +240,9 @@ If `devcontainer --version` fails:
 brew install devcontainer
 ```
 
-**Linux / WSL:**
+**macOS (without Homebrew) / Linux / WSL:**
 ```bash
-sudo npm install -g @devcontainers/cli
+npm install -g @devcontainers/cli
 ```
 
 If npm is not found, install Node.js first (see [Prerequisites](#installing-prerequisites)).


### PR DESCRIPTION
## Summary

- Add macOS Direct Download tab for users without Homebrew
- Simplify Node.js setup (remove fnm, point to nodejs.org)
- Add HTTPS to install URLs for clarity
- Consolidate checksum generation in release workflow
- Update troubleshooting to cover macOS without Homebrew

## Test Plan

- [x] Review installation docs render correctly
- [x] Verify all install URLs are properly formatted
- [x] Confirm release workflow consolidation is correct