### PR TITLE
fix: eliminate duplicate template prompt in devbox new

### DIFF
--- a/docs/reference/new.md
+++ b/docs/reference/new.md
@@ -114,8 +114,16 @@ After creating a project, you're prompted to clone it locally:
 ? Clone this project locally now? (Y/n)
 ```
 
-- **Yes** - Runs `devbox clone <project>` to sync locally
+- **Yes** - Syncs the project locally, then offers to start the dev container
 - **No** - Project exists only on remote; clone later with `devbox clone`
+
+If you choose to clone, DevBox also prompts:
+
+```
+? Start dev container now? (Y/n)
+```
+
+This lets you go from `devbox new` to a running container in a single flow.
 
 ## Exit Codes
 

--- a/src/commands/clone.ts
+++ b/src/commands/clone.ts
@@ -38,7 +38,7 @@ import inquirer from "inquirer";
  * Clone a single project from remote. This is the core clone logic
  * used by both direct invocation and interactive multi-clone.
  */
-async function cloneSingleProject(
+export async function cloneSingleProject(
 	project: string,
 	remoteName: string,
 	config: ReturnType<typeof loadConfig>,


### PR DESCRIPTION
## Summary

Fixes the UX issue where `devbox new` would redundantly prompt for remote selection after creating a project. The old flow called `cloneCommand()` which re-prompted the user. Now it directly calls `cloneSingleProject()` with the already-known remote context, eliminating the duplicate interaction.

Also adds a race-condition fallback: if Mutagen hasn't synced the devcontainer.json locally yet, we write it directly. Extracts workspace config into a reusable helper to avoid duplication.

After cloning, users are now offered to start the dev container immediately, streamlining the new-project flow into a single unbroken sequence.

## Changes

- Export `cloneSingleProject` from clone.ts for reuse
- Refactor `offerClone()` to accept remote/config context and call clone directly
- Add local devcontainer.json fallback with error handling
- Offer to start container after clone succeeds
- Extract workspace settings into `withWorkspaceSettings()` helper
- Update docs to reflect the new UX flow