### PR TITLE
docs: move analytics config to environment variables

### DIFF
--- a/docs/.env.example
+++ b/docs/.env.example
@@ -1,0 +1,2 @@
+VITE_RYBBIT_SRC=https://your-rybbit-instance.example.com/api/script.js
+VITE_RYBBIT_SITE_ID=your-site-id

--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -1,6 +1,25 @@
-import { defineConfig } from 'vitepress'
+import { resolve } from 'node:path'
+import { defineConfig, type HeadConfig } from 'vitepress'
+import { loadEnv } from 'vite'
 import llmstxt from 'vitepress-plugin-llms'
 import { commands } from './commands'
+
+const env = loadEnv('', resolve(import.meta.dirname, '..'))
+
+const head: HeadConfig[] = [
+  ['link', { rel: 'icon', type: 'image/svg+xml', href: '/devbox-logo-grey.svg' }],
+]
+
+if (env.VITE_RYBBIT_SRC && env.VITE_RYBBIT_SITE_ID) {
+  head.push([
+    'script',
+    {
+      src: env.VITE_RYBBIT_SRC,
+      'data-site-id': env.VITE_RYBBIT_SITE_ID,
+      defer: ''
+    }
+  ])
+}
 
 export default defineConfig({
   title: 'DevBox',
@@ -15,17 +34,7 @@ export default defineConfig({
     plugins: [llmstxt()]
   },
 
-  head: [
-    ['link', { rel: 'icon', type: 'image/svg+xml', href: '/devbox-logo-grey.svg' }],
-    [
-      'script',
-      {
-        src: 'https://rybbit.jcjmrhjts.uk/api/script.js',
-        'data-site-id': '8bedf30d2eff',
-        defer: ''
-      }
-    ],
-  ],
+  head,
 
   themeConfig: {
     logo: '/devbox-logo-grey.svg',


### PR DESCRIPTION
## Summary
- Replace hardcoded Rybbit analytics script URL and site ID in VitePress config with environment variables (`VITE_RYBBIT_SRC`, `VITE_RYBBIT_SITE_ID`) loaded via Vite's `loadEnv`
- Analytics `<script>` tag is now conditionally injected only when both env vars are present, preventing broken tags in local dev or preview environments
- Add `docs/.env.example` with placeholder values for developer reference

## Test plan
- [ ] Verify `bun run docs:dev` works without a `docs/.env` file (no analytics script in HTML)
- [ ] Verify `bun run docs:dev` works with a `docs/.env` file containing valid values (analytics script injected)
- [ ] Confirm `docs/.env` is gitignored and not committed