### PR TITLE
docs: add audit skill, update CHANGELOG, fix stale references

### DIFF
--- a/.claude/skills/skybox-audit-docs/SKILL.md
+++ b/.claude/skills/skybox-audit-docs/SKILL.md
@@ -1,0 +1,249 @@
+---
+name: skybox-audit-docs
+description: Use when needing to thoroughly check the docs for completeness, and suggest other improvements in its layout or flow to make the docs better to understand and easier to parse for a user. Use when auditing documentation quality, before a release, or when another skill detects significant documentation gaps.
+---
+
+# Documentation Audit
+
+## Overview
+
+Comprehensive documentation audit that validates completeness against the codebase (source code, CHANGELOG, and CLAUDE.md) and reviews UX quality (structure, formatting, discoverability). Runs automated analysis first, then presents findings interactively for triage, and produces a curated markdown report with a task list.
+
+## When to Use
+
+- Before a release (invoked by `skybox-prep-release`)
+- When the user says "audit docs", "check docs", "review documentation"
+- When `skybox-update-docs` detects more than 3 pages needing updates and suggests a full audit
+- When the user asks about documentation completeness, quality, or improvements
+
+## Process
+
+```dot
+digraph audit_flow {
+    rankdir=TB;
+
+    subgraph cluster_auto {
+        label="Automated (Parallel Subagents)";
+        style=dashed;
+        completeness [label="Phase 1\nCompleteness Audit" shape=box];
+        ux [label="Phase 2\nUX & Readability Review" shape=box];
+    }
+
+    merge [label="Merge & deduplicate\nfindings" shape=box];
+    interactive [label="Phase 3\nInteractive Review\n(category by category)" shape=box];
+    triage [label="User triages each finding:\naccept / reject / modify" shape=diamond];
+    report [label="Phase 4\nGenerate Report\n+ Claude Code Tasks" shape=box];
+    done [label="Audit complete" shape=doublecircle];
+
+    completeness -> merge;
+    ux -> merge;
+    merge -> interactive -> triage;
+    triage -> interactive [label="next finding"];
+    triage -> report [label="all reviewed"];
+    report -> done;
+}
+```
+
+## Phase 1: Completeness Audit
+
+Run as a subagent. Cross-reference three sources to find gaps, staleness, and drift.
+
+### 1.1 Source Code vs Docs
+
+**Commands:**
+- Read every file in `src/commands/` — extract command name, arguments, options, and flags from the Commander.js definitions
+- For each command, verify a matching page exists in `docs/reference/` with all arguments and options documented
+- Cross-check against `docs/.vitepress/commands.ts` (the single source of truth for sidebar) — flag any command missing from the sidebar or sidebar entries with no matching doc page
+
+**Config:**
+- Read `src/types/index.ts` — extract all config-related interfaces and their fields
+- Verify `docs/reference/configuration.md` documents every field
+- Read `src/lib/constants.ts` — extract environment variables, default values, and template definitions
+- Verify docs reflect current values (not outdated defaults)
+
+**Templates:**
+- Read `TEMPLATES` constant in `src/lib/constants.ts` — verify `docs/reference/custom-templates.md` lists all built-in templates and their fields match
+
+### 1.2 CHANGELOG vs Docs
+
+- Read `CHANGELOG.md` — identify all entries since the last git tag (`git describe --tags --abbrev=0`, or root commit if no tags)
+- For each Added/Changed/Fixed entry, check if the corresponding docs page was updated (search for relevant keywords in docs files)
+- Flag entries with no apparent docs coverage
+
+### 1.3 CLAUDE.md vs Docs vs Source
+
+- Compare CLAUDE.md "Key Files Reference" table against actual files in `src/` — flag missing or stale entries
+- Compare CLAUDE.md "Environment Variables" table against `docs/reference/configuration.md` env vars section and `src/lib/constants.ts` — flag inconsistencies
+- Check if CLAUDE.md "Known Gotchas" that affect users are surfaced in `docs/guide/troubleshooting.md` where relevant
+
+### 1.4 Severity Classification
+
+Each finding gets a severity:
+- **missing** — not documented at all (feature, option, or config exists in code but not in docs)
+- **stale** — documented but outdated (values, behavior, or structure changed)
+- **drift** — inconsistent between sources (docs says one thing, CLAUDE.md says another, code does a third)
+
+## Phase 2: UX & Readability Review
+
+Run as a separate subagent in parallel with Phase 1. Analyze docs from a user's perspective.
+
+### 2.1 Structure & Flow
+
+- Map the learning journey: homepage → installation → quick start → concepts → workflows → reference
+- For each page, check it has clear "next step" guidance — flag dead ends (pages with no links to what to read next)
+- Check the guide section progresses simple → advanced without assuming knowledge not yet introduced
+- Verify the sidebar order matches the recommended reading order
+
+### 2.2 Scannability & Formatting
+
+- Flag pages over ~500 lines as candidates for splitting
+- Check heading hierarchy is consistent (no skipped levels like h2 → h4)
+- Verify all command reference pages follow the same structural template (usage, arguments, options, description, examples, exit codes, see also)
+- Look for walls of text (>10 consecutive lines of prose without a heading, table, code block, or callout)
+- Verify code examples have language tags for syntax highlighting
+- Check tables are used effectively for structured data (options, flags, env vars)
+
+### 2.3 Cross-linking & Discoverability
+
+- For each page, check that mentions of other SkyBox concepts link to their dedicated pages (e.g., "sync" in a guide page should link to the sync section in concepts)
+- Check for orphan pages — pages not linked from any other page or sidebar
+- Verify "See Also" sections on command pages reference relevant sibling commands
+- Check that troubleshooting entries link back to the feature docs they relate to
+- Verify the homepage hero actions link to the right starting points
+
+### 2.4 Impact Classification
+
+Each finding gets an impact rating:
+- **high** — users will get lost or confused (missing navigation, wrong reading order, dead ends)
+- **medium** — suboptimal but navigable (inconsistent formatting, long pages, missing cross-links)
+- **low** — polish (minor formatting, extra cross-links that would be nice to have)
+
+## Phase 3: Interactive Review
+
+After both automated phases complete, present findings to the user one category at a time.
+
+### Presentation Order
+
+1. **Completeness: Missing** — features/options with no docs (highest priority)
+2. **Completeness: Stale/Drift** — docs that exist but are outdated or inconsistent
+3. **UX: High impact** — structure/flow issues that confuse users
+4. **UX: Medium impact** — formatting and discoverability improvements
+5. **UX: Low impact** — polish items
+
+### For Each Category
+
+- Present a summary: count of findings and brief list
+- Show each finding with:
+  - What's wrong (specific file and line/section reference)
+  - Why it matters
+  - Suggested fix (concrete and actionable)
+- Ask the user to triage using `AskUserQuestion`:
+  - **Accept** — include in final report as-is
+  - **Modify** — edit the suggestion before including
+  - **Reject** — skip this finding
+  - **Accept all remaining in this category** — speed through low-priority items
+
+### Running Progress
+
+Show progress after each decision:
+```
+[8/23 findings reviewed — 6 accepted, 1 modified, 1 rejected]
+```
+
+## Phase 4: Report Generation
+
+After all findings are triaged, generate the final report.
+
+### Output File
+
+Write to `.context/docs-audit-YYYY-MM-DD.md`. Create `.context/` if it doesn't exist. Overwrite if a report for today already exists.
+
+### Report Structure
+
+```markdown
+# SkyBox Documentation Audit — YYYY-MM-DD
+
+## Summary
+
+- **Findings accepted:** X (Y completeness, Z UX)
+- **Severity breakdown:** N missing, N stale, N drift, N high-UX, N medium-UX, N low-UX
+- **Effort estimate:** N quick wins, N moderate, N substantial
+
+## Completeness Findings
+
+### Missing Documentation
+
+- **[finding title]** — `src/path/file.ts` defines `--flag` but `docs/reference/command.md` does not document it
+  - **Fix:** Add `--flag` to the Options table in `docs/reference/command.md`
+  - **Effort:** Quick win
+
+### Stale / Drifted Documentation
+
+- **[finding title]** — `docs/reference/configuration.md` says default is X, but `src/lib/constants.ts` defines Y
+  - **Fix:** Update the default value in `docs/reference/configuration.md`
+  - **Effort:** Quick win
+
+## UX Findings
+
+### Structure & Flow
+
+- **[finding title]** — `docs/guide/concepts.md` references encryption before `docs/guide/installation.md` introduces it
+  - **Fix:** Add a forward-link or reorder sections
+  - **Effort:** Moderate
+
+### Scannability & Formatting
+
+- ...
+
+### Cross-linking & Discoverability
+
+- ...
+
+## Task List
+
+Ordered by priority (high → low), grouped by effort.
+
+### Quick Wins
+
+- [ ] [description] — `docs/path/to/file.md`
+- [ ] [description] — `docs/path/to/file.md`
+
+### Moderate Effort
+
+- [ ] [description] — `docs/path/to/file.md`, `docs/other/file.md`
+
+### Substantial
+
+- [ ] [description] — multiple files, may need new page
+```
+
+### Claude Code Task Creation
+
+After writing the report, create Claude Code tasks via `TaskCreate` for each accepted finding so they're immediately trackable. Group related findings into single tasks where it makes sense (e.g., "Update all missing options for the `up` command" rather than one task per option).
+
+## Integration with Other Skills
+
+### Called by `skybox-prep-release`
+
+When invoked as part of release prep:
+- Run Phases 1-3 as normal (interactive triage)
+- If any **missing** severity findings are accepted, warn that docs should be updated before tagging
+- **Stale/drift** and UX findings don't block the release but are included in the report
+- The release prep skill references the generated report in its own audit output
+
+### Suggested by `skybox-update-docs`
+
+When `skybox-update-docs` detects more than 3 pages needing updates during its analysis step, it should suggest:
+```
+This looks like it needs a broader audit. Consider running `skybox-audit-docs` for a comprehensive review.
+```
+
+## Key Rules
+
+- **Parallel subagents** — Phase 1 and Phase 2 MUST run as parallel subagents via the Task tool for speed
+- **Never skip interactive triage** — always present findings for user review before generating the report
+- **Concrete suggestions only** — every finding must include a specific, actionable fix with file paths
+- **No false positives** — if unsure whether something is a gap, verify by reading both the source code and the docs before flagging
+- **Preserve existing quality** — the docs are already well-structured; focus on gaps and improvements, not rewriting what works
+- **Report is ephemeral** — `.context/` is gitignored; the report is working state, not a permanent artifact
+- **Read fresh every time** — do not assume docs or source content; always read files at the start of each run

--- a/.claude/skills/skybox-prep-release/SKILL.md
+++ b/.claude/skills/skybox-prep-release/SKILL.md
@@ -64,8 +64,10 @@ Gather all information into a single report before changing anything.
 
 ### 4. Docs Audit
 
-- Invoke `noor:update-docs` analysis step (Analyze + Propose only, no execution)
-- Include any doc gaps in the report
+- Invoke `skybox-audit-docs` — run the full interactive audit (Phases 1-4)
+- If any **missing** severity completeness findings are accepted, warn that docs should be updated before tagging
+- Stale/drift and UX findings don't block the release but are included in the report
+- Reference the generated `.context/docs-audit-YYYY-MM-DD.md` report in this release audit output
 
 ### Report Format
 
@@ -108,7 +110,7 @@ After user approves the report, execute each step with a checkpoint:
 
 ### 3. Update Docs
 
-- If the audit found doc gaps, invoke `noor:update-docs` execute step
+- If the audit found doc gaps, invoke `skybox-update-docs` execute step
 - If no gaps were found, skip with confirmation
 
 ### 4. Update IMPLEMENTATION.md

--- a/.claude/skills/skybox-update-docs/SKILL.md
+++ b/.claude/skills/skybox-update-docs/SKILL.md
@@ -83,3 +83,4 @@ For each approved change:
 - **Match existing style** — read a sibling docs page first to match tone, structure, and formatting.
 - **Don't document internals** — only user-facing behavior belongs in docs.
 - **When called as a sub-step** by another skill (like `prep-release`), run only the Analyze and Propose steps. Let the calling skill decide whether to execute.
+- **Suggest full audit when needed** — if the Analyze step finds more than 3 pages needing updates, suggest: "This looks like it needs a broader audit. Consider running `skybox-audit-docs` for a comprehensive review." Let the user decide whether to switch to the full audit or continue with targeted updates.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,37 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - **Dry-Run Mode** (`--dry-run`): Global flag to preview what any command would do without executing side effects (SSH, Docker, filesystem writes, sync sessions)
+- **Security Hardening**: GPG signature verification for Mutagen downloads, audit logging (`SKYBOX_AUDIT=1`), runtime config schema validation, Mutagen binary checksum verification, lockfile integrity verification
+- **Integration & E2E Test Suites**: Layered Docker integration and remote E2E test infrastructure with CI workflows and security hardening
+- **Interactive Remote Delete**: Multi-select flow for `skybox rm --remote` — select a remote, pick projects via checkbox, confirm, and optionally clean up local copies
+- **Shell Integration**: Auto-start containers on `cd` into project directories (`skybox hook bash/zsh`, `auto_up` config option, background execution)
+- **LLMs.txt**: Machine-readable documentation for AI tools, sitemap, and robots.txt
+
+### Changed
+
+- **DevBox → SkyBox**: Complete project rename across CLI binary, commands, documentation, configuration, and tests
+- **Local Sessions**: Replaced remote SSH-based lock system with local file-based sessions (synced via Mutagen) for simpler multi-machine conflict detection
+- **Feature-Based Templates**: Unified devcontainer templates to feature-based architecture with dev container features
+- Analytics configuration moved to environment variables
+- Doctor command suggests `brew install devcontainer` on macOS when Homebrew is available
+- Bumped dependencies (ora, @biomejs/biome, @types/react)
+
+### Fixed
+
+- Insecure file permissions on config (now 0o600) and directories (now 0o700)
+- Predictable temp directory paths vulnerable to symlink attacks
+- Missing shell argument escaping in remote SSH commands
+- Weak Argon2 parameters — strengthened to OWASP minimums
+- Inconsistent project name validation across commands
+- Missing remote path validation for shell metacharacters
+- Duplicate template prompt in `skybox new` workflow
+- SSH key not passed to `getRemoteProjects` for remotes with explicit key files
+
+### Removed
+
+- `skybox locks` command (replaced by local session system)
+- Remote SSH-based lock polling
+- Architecture pages from public documentation (now internal-only)
 
 ## [0.7.7] - 2026-02-01
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -381,8 +381,9 @@ Uses Docker with devcontainer spec:
 
 Before ending a session where code was written or modified:
 
-1. **Update CLAUDE.md** — If you learned something useful (new gotchas, conventions, commands, architectural decisions), run `/claude-md-management:revise-claude-md`. Skip if the session was simple Q&A or trivial changes.
-2. **Update task tracker** — If you completed tasks from a plan, mark them done with `TaskUpdate` and update `plans/IMPLEMENTATION.md` with `[x]` and commit hashes in `plans/archive/ARCHIVED-IMPLEMENTATION.md`.
+1. **Update CHANGELOG.md** — Add entries to the `[Unreleased]` section for any user-facing changes (features, fixes, breaking changes, removals). Follow [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) format with categories: Added, Changed, Fixed, Removed. Skip for docs-only or internal-only changes (CI tweaks, plan archiving, skill edits).
+2. **Update CLAUDE.md** — If you learned something useful (new gotchas, conventions, commands, architectural decisions), run `/claude-md-management:revise-claude-md`. Skip if the session was simple Q&A or trivial changes.
+3. **Update task tracker** — If you completed tasks from a plan, mark them done with `TaskUpdate` and update `plans/IMPLEMENTATION.md` with `[x]` and commit hashes in `plans/archive/ARCHIVED-IMPLEMENTATION.md`.
 
 Note: `bun run check` is enforced automatically by a native Stop hook — no manual step needed.
 

--- a/docs/guide/installation.md
+++ b/docs/guide/installation.md
@@ -181,7 +181,7 @@ If the SSH connection test fails:
 If Mutagen fails to install automatically:
 
 1. Check your internet connection
-2. Try manual installation: https://mutagen.io/documentation/introduction/installation
+2. Try manual installation: [Mutagen](https://mutagen.io/documentation/introduction/installation)
 3. Run `skybox init` again after installing manually
 
 ### Permission Denied Errors

--- a/plans/2026-02-05-docs-audit-skill-design.md
+++ b/plans/2026-02-05-docs-audit-skill-design.md
@@ -1,0 +1,48 @@
+# Documentation Audit Skill Design
+
+> Brainstormed 2026-02-05
+
+## Purpose
+
+Create a Claude Code skill (`skybox-audit-docs`) that comprehensively audits SkyBox documentation for completeness against the codebase and reviews UX quality, producing an interactive review followed by a curated report with actionable tasks.
+
+## Design Decisions
+
+| Decision | Choice | Rationale |
+|----------|--------|-----------|
+| Output format | Interactive review → markdown report | Filters noise interactively; final report only contains what user cares about |
+| Completeness sources | Source code + CHANGELOG + CLAUDE.md | Full triangulation catches drift anywhere |
+| UX review scope | Structure, formatting, and discoverability | Holistic review since we're already investing the audit time |
+| Trigger | Manual + release-gated | Docs never slip through unaudited before a tag |
+| Report location | `.context/docs-audit-YYYY-MM-DD.md` | Gitignored ephemeral working state |
+
+## Architecture
+
+### 4 Phases
+
+1. **Completeness Audit** (parallel subagent) — cross-references `src/commands/`, `src/types/index.ts`, `src/lib/constants.ts`, `CHANGELOG.md`, and `CLAUDE.md` against docs pages
+2. **UX & Readability Review** (parallel subagent) — analyzes structure/flow, scannability/formatting, cross-linking/discoverability
+3. **Interactive Review** — presents findings category-by-category for user triage (accept/reject/modify)
+4. **Report Generation** — writes curated markdown report + creates Claude Code tasks
+
+### Severity/Impact Classification
+
+- Completeness: **missing**, **stale**, **drift**
+- UX: **high**, **medium**, **low**
+
+### Integration Points
+
+- `skybox-prep-release` invokes the full audit; **missing** findings warn before tagging
+- `skybox-update-docs` suggests the audit when >3 pages need updates
+
+## Files Created/Modified
+
+| File | Action |
+|------|--------|
+| `.claude/skills/skybox-audit-docs/SKILL.md` | Created |
+| `.claude/skills/skybox-prep-release/SKILL.md` | Updated docs audit step |
+| `.claude/skills/skybox-update-docs/SKILL.md` | Added audit suggestion rule |
+
+## Documentation Updates Required
+
+None — this is an internal tooling skill, not a user-facing feature.


### PR DESCRIPTION
Prepares documentation infrastructure and backfills CHANGELOG for unreleased work.

**Changes:**
- Create `skybox-audit-docs` skill for comprehensive documentation audits (completeness, UX/readability)
- Integrate with `skybox-prep-release` to gate releases on missing docs
- Backfill CHANGELOG with all unreleased features, fixes, and breaking changes from recent commits
- Fix stale skill reference and clarify ambiguous CHANGELOG entries
- Update session checklist ordering in CLAUDE.md