### PR TITLE
refactor: simplify duplicated sync, prompts, and test contexts

### DIFF
--- a/src/commands/new.ts
+++ b/src/commands/new.ts
@@ -12,6 +12,7 @@ import {
 	WORKSPACE_PATH_PREFIX,
 } from "@lib/constants.ts";
 import { hasLocalDevcontainerConfig } from "@lib/container.ts";
+import { offerStartContainer } from "@lib/container-start.ts";
 import { getErrorMessage } from "@lib/errors.ts";
 import { getProjectPath } from "@lib/project.ts";
 import { validateProjectName } from "@lib/projectTemplates.ts";
@@ -348,19 +349,9 @@ const offerClone = async (
 		}
 	}
 
-	console.log();
-	const { startContainer } = await inquirer.prompt([
-		{
-			type: "confirm",
-			name: "startContainer",
-			message: "Start dev container now?",
-			default: true,
-		},
-	]);
-
-	if (startContainer) {
-		await upCommand(projectName, {});
-	} else {
-		info(`Run 'skybox up ${projectName}' when ready to start working.`);
-	}
+	await offerStartContainer({
+		projectName,
+		defaultStart: true,
+		onStart: async (selectedProject) => upCommand(selectedProject, {}),
+	});
 };

--- a/src/commands/status.ts
+++ b/src/commands/status.ts
@@ -1,6 +1,6 @@
 // src/commands/status.ts
 
-import { existsSync, readdirSync, statSync } from "node:fs";
+import { existsSync, statSync } from "node:fs";
 import { join } from "node:path";
 import { getProjectRemote, getRemoteHost } from "@commands/remote.ts";
 import { requireConfig } from "@lib/config.ts";
@@ -8,6 +8,7 @@ import { getContainerInfo, getContainerStatus } from "@lib/container.ts";
 import { getGitInfo as getSharedGitInfo } from "@lib/git.ts";
 import { getSyncStatus, sessionName } from "@lib/mutagen.ts";
 import { getProjectsDir } from "@lib/paths.ts";
+import { getLocalProjects } from "@lib/project.ts";
 import { formatRelativeTime as formatRelativeTimeShared } from "@lib/relative-time.ts";
 import {
 	checkSessionConflict,
@@ -339,24 +340,13 @@ export const statusCommand = async (project?: string): Promise<void> => {
 const showOverview = async (): Promise<void> => {
 	const projectsDir = getProjectsDir();
 	if (!existsSync(projectsDir)) {
-		console.log();
-		console.log(
-			"No projects found. Use 'skybox clone' or 'skybox push' to get started.",
-		);
+		printNoProjectsMessage();
 		return;
 	}
 
-	const entries = readdirSync(projectsDir);
-	const projectDirs = entries.filter((entry) => {
-		const fullPath = join(projectsDir, entry);
-		return statSync(fullPath).isDirectory();
-	});
-
+	const projectDirs = getLocalProjects();
 	if (projectDirs.length === 0) {
-		console.log();
-		console.log(
-			"No projects found. Use 'skybox clone' or 'skybox push' to get started.",
-		);
+		printNoProjectsMessage();
 		return;
 	}
 
@@ -369,6 +359,14 @@ const showOverview = async (): Promise<void> => {
 	console.log();
 	formatOverviewTable(summaries);
 	console.log();
+};
+
+// print the shared empty-state message when no local projects are available
+const printNoProjectsMessage = (): void => {
+	console.log();
+	console.log(
+		"No projects found. Use 'skybox clone' or 'skybox push' to get started.",
+	);
 };
 
 // display detailed status for a single project

--- a/src/lib/container-start.ts
+++ b/src/lib/container-start.ts
@@ -1,0 +1,38 @@
+import { info } from "@lib/ui.ts";
+import inquirer from "inquirer";
+
+interface OfferStartContainerOptions {
+	projectName: string;
+	defaultStart: boolean;
+	onStart: (projectName: string) => Promise<void>;
+	onDeclineMessages?: string[];
+}
+
+// offer to start a project's dev container and handle shared prompt messaging
+export const offerStartContainer = async (
+	options: OfferStartContainerOptions,
+): Promise<boolean> => {
+	const { projectName, defaultStart, onStart, onDeclineMessages } = options;
+
+	console.log();
+	const { startContainer } = await inquirer.prompt([
+		{
+			type: "confirm",
+			name: "startContainer",
+			message: "Start dev container now?",
+			default: defaultStart,
+		},
+	]);
+
+	if (startContainer) {
+		await onStart(projectName);
+		return true;
+	}
+
+	const fallbackMessage = `Run 'skybox up ${projectName}' when ready to start working.`;
+	for (const message of onDeclineMessages || [fallbackMessage]) {
+		info(message);
+	}
+
+	return false;
+};

--- a/src/lib/download.ts
+++ b/src/lib/download.ts
@@ -15,14 +15,34 @@ import { getBinDir, getMutagenPath } from "@lib/paths.ts";
 import { execa } from "execa";
 import { extract } from "tar";
 
+interface MutagenPlatformInfo {
+	os: "darwin" | "linux";
+	cpu: "arm64" | "amd64";
+	filename: string;
+}
+
+// normalize platform/arch into mutagen release naming components
+export const getMutagenPlatformInfo = (
+	platform: string,
+	arch: string,
+	version: string,
+): MutagenPlatformInfo => {
+	const os = platform === "darwin" ? "darwin" : "linux";
+	const cpu = arch === "arm64" ? "arm64" : "amd64";
+	return {
+		os,
+		cpu,
+		filename: `mutagen_${os}_${cpu}_v${version}.tar.gz`,
+	};
+};
+
 // get mutagen download url
 export const getMutagenDownloadUrl = (
 	platform: string,
 	arch: string,
 	version: string,
 ): string => {
-	const os = platform === "darwin" ? "darwin" : "linux";
-	const cpu = arch === "arm64" ? "arm64" : "amd64";
+	const { os, cpu } = getMutagenPlatformInfo(platform, arch, version);
 	return `https://github.com/${MUTAGEN_REPO}/releases/download/v${version}/mutagen_${os}_${cpu}_v${version}.tar.gz`;
 };
 
@@ -104,9 +124,7 @@ export const downloadMutagen = async (
 		return { success: false, error: `Unsupported platform: ${platform}` };
 	}
 
-	const os = platform === "darwin" ? "darwin" : "linux";
-	const cpu = arch === "arm64" ? "arm64" : "amd64";
-	const filename = `mutagen_${os}_${cpu}_v${MUTAGEN_VERSION}.tar.gz`;
+	const { filename } = getMutagenPlatformInfo(platform, arch, MUTAGEN_VERSION);
 	const url = getMutagenDownloadUrl(platform, arch, MUTAGEN_VERSION);
 	const binDir = getBinDir();
 	const tarPath = join(binDir, "mutagen.tar.gz");

--- a/src/lib/project-sync.ts
+++ b/src/lib/project-sync.ts
@@ -1,0 +1,70 @@
+import { saveConfig } from "@lib/config.ts";
+import { waitForSync } from "@lib/mutagen.ts";
+import { createProjectSyncSession } from "@lib/sync-session.ts";
+import type { SkyboxConfigV2 } from "@typedefs/index.ts";
+
+interface FinalizeProjectSyncOptions {
+	projectName: string;
+	localPath: string;
+	remoteHost: string;
+	remotePath: string;
+	ignores: string[];
+	syncPaths?: string[];
+	config: SkyboxConfigV2;
+	remoteName: string;
+	onProgress?: (message: string) => void;
+}
+
+type SyncFailureStage = "create" | "sync";
+
+export type FinalizeProjectSyncResult =
+	| { success: true }
+	| { success: false; stage: SyncFailureStage; error: string };
+
+// create a project sync session, wait for initial flush, and register the project in config
+export const finalizeProjectSync = async (
+	options: FinalizeProjectSyncOptions,
+): Promise<FinalizeProjectSyncResult> => {
+	const {
+		projectName,
+		localPath,
+		remoteHost,
+		remotePath,
+		ignores,
+		syncPaths,
+		config,
+		remoteName,
+		onProgress,
+	} = options;
+
+	const createResult = await createProjectSyncSession({
+		project: projectName,
+		localPath,
+		remoteHost,
+		remotePath,
+		ignores,
+		syncPaths,
+	});
+
+	if (!createResult.success) {
+		return {
+			success: false,
+			stage: "create",
+			error: createResult.error || "Failed to create sync session",
+		};
+	}
+
+	const syncResult = await waitForSync(projectName, onProgress);
+	if (!syncResult.success) {
+		return {
+			success: false,
+			stage: "sync",
+			error: syncResult.error || "Sync failed",
+		};
+	}
+
+	config.projects[projectName] = { remote: remoteName };
+	saveConfig(config);
+
+	return { success: true };
+};

--- a/tests/helpers/test-utils.ts
+++ b/tests/helpers/test-utils.ts
@@ -40,7 +40,7 @@ export const createTestContext = (name: string): TestContext => {
 		testDir,
 		cleanup: () => {
 			if (existsSync(testDir)) {
-				rmSync(testDir, { recursive: true });
+				rmSync(testDir, { recursive: true, force: true });
 			}
 			if (originalEnv) {
 				process.env.SKYBOX_HOME = originalEnv;


### PR DESCRIPTION
## Summary
- extract shared project sync finalization flow into src/lib/project-sync.ts and reuse from clone/push
- extract shared dev-container start prompt into src/lib/container-start.ts and reuse from clone/push/new
- reduce duplication in status project discovery, encryption fallback, remote archive temp-dir handling, and mutagen platform normalization
- reuse shared test context lifecycle in integration/e2e helpers and align cleanup behavior

## Validation
- bun run typecheck
- bun run check:ci
- bun run test
