### PR TITLE
docs: add unreleased changelog notes for merged refactor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **Internal Refactor**: Consolidated shared sync finalization and start-container prompt flows across `clone`, `push`, and `new` for consistency, without changing CLI behavior.
+- **Internal Refactor**: Reduced duplication in encryption/archive/download internals and test context lifecycle helpers, with no user-facing behavior changes.
+
 ## [0.8.0] - 2026-02-07
 
 ### Added


### PR DESCRIPTION
## Summary
- add missing [Unreleased] changelog entries for the already-merged refactor work from #47
- document the changes as internal, behavior-preserving refactors

## Why
PR #47 was merged before the changelog commit was added, so this follow-up PR carries only that changelog update.

## Validation
- bun run typecheck