### PR TITLE
docs: fix reporting links with mailto subject fallbacks

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -59,8 +59,8 @@ appointed representative at an online or offline event.
 ## Enforcement
 
 Instances of abusive, harassing, or otherwise unacceptable behavior may be
-reported to the community leaders through a private report at
-[SkyBox private reporting](https://github.com/NoorXLabs/SkyBox/security/advisories/new).
+reported to the community leaders privately at
+[info@noorxlabs.com](mailto:info@noorxlabs.com?subject=SkyBox%20Code%20of%20Conduct%20Report).
 All complaints will be reviewed and investigated promptly and fairly.
 
 All community leaders are obligated to respect the privacy and security of the

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -17,6 +17,10 @@ Use GitHub Private Vulnerability Reporting:
 
 - [Report a vulnerability](https://github.com/NoorXLabs/SkyBox/security/advisories/new)
 
+If that link is unavailable, report privately by email:
+
+- [info@noorxlabs.com](mailto:info@noorxlabs.com?subject=SkyBox%20Security%20Vulnerability%20Report)
+
 Include as much detail as possible:
 
 - Affected version(s)
@@ -32,4 +36,3 @@ Include as much detail as possible:
 
 After validation, maintainers will coordinate remediation and release timing.
 We will credit reporters who want public acknowledgment.
-


### PR DESCRIPTION
## Summary

Fixes dead-link reporting paths by switching to mailto links with prefilled subjects.

## What Changed

- Updated `CODE_OF_CONDUCT.md` to use private conduct reporting via:
  - `mailto:info@noorxlabs.com?subject=SkyBox%20Code%20of%20Conduct%20Report`
- Updated `SECURITY.md` to keep GitHub advisory reporting as primary and add fallback email:
  - `mailto:info@noorxlabs.com?subject=SkyBox%20Security%20Vulnerability%20Report`

## Why

The advisory URL can be unavailable depending on repository visibility/settings. Email fallback prevents dead-end reporting paths.

## Validation

- Verified markdown links in both files
- Confirmed branch diff only contains docs updates
