### PR TITLE
docs: add SEO metadata and remove source install method

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -23,7 +23,8 @@ if (env.VITE_RYBBIT_SRC && env.VITE_RYBBIT_SITE_ID) {
 
 export default defineConfig({
   title: 'SkyBox',
-  description: 'Development environment management CLI',
+  description: 'Local-first development containers with remote sync. Run containers locally, sync code bidirectionally, and switch between machines seamlessly.',
+  lang: 'en-US',
   srcExclude: ['**/architecture/**', '**/snippets/**'],
 
   sitemap: {
@@ -35,6 +36,31 @@ export default defineConfig({
   },
 
   head,
+
+  transformHead({ pageData }) {
+    const head: HeadConfig[] = []
+    const siteUrl = 'https://skybox.noorxlabs.com'
+    const pagePath = pageData.relativePath
+      .replace(/index\.md$/, '')
+      .replace(/\.md$/, '')
+    const pageUrl = `${siteUrl}/${pagePath}`
+    const title = pageData.frontmatter.title || pageData.title
+    const description = pageData.frontmatter.description || 'Local-first development containers with remote sync.'
+
+    head.push(['meta', { property: 'og:title', content: title }])
+    head.push(['meta', { property: 'og:description', content: description }])
+    head.push(['meta', { property: 'og:type', content: 'website' }])
+    head.push(['meta', { property: 'og:url', content: pageUrl }])
+    head.push(['meta', { property: 'og:site_name', content: 'SkyBox' }])
+    head.push(['meta', { property: 'og:image', content: `${siteUrl}/og-image.png` }])
+    head.push(['meta', { name: 'twitter:card', content: 'summary_large_image' }])
+    head.push(['meta', { name: 'twitter:image', content: `${siteUrl}/og-image.png` }])
+    head.push(['meta', { name: 'twitter:title', content: title }])
+    head.push(['meta', { name: 'twitter:description', content: description }])
+    head.push(['link', { rel: 'canonical', href: pageUrl }])
+
+    return head
+  },
 
   themeConfig: {
     logo: '/skybox-logo-grey.svg',

--- a/docs/guide/concepts.md
+++ b/docs/guide/concepts.md
@@ -1,3 +1,8 @@
+---
+title: Core Concepts
+description: Understand SkyBox projects, containers, bidirectional sync via Mutagen, remote server architecture, and session-based multi-machine coordination.
+---
+
 # Core Concepts
 
 This page explains the key concepts behind SkyBox: how projects, containers, sync, and the remote server work together.

--- a/docs/guide/index.md
+++ b/docs/guide/index.md
@@ -1,3 +1,8 @@
+---
+title: Introduction
+description: Learn what SkyBox is and how it manages local-first development containers with remote sync, multi-machine workflows, and editor integration.
+---
+
 # Introduction
 
 SkyBox is a CLI tool for local-first development containers with remote sync. It provides the best of both worlds: run your containers locally for speed and full resource access while automatically syncing your code to a remote server for backup and multi-machine workflows.

--- a/docs/guide/installation.md
+++ b/docs/guide/installation.md
@@ -1,3 +1,8 @@
+---
+title: Installation
+description: Install SkyBox and its prerequisites including Docker and the Devcontainer CLI. Set up your first remote server connection.
+---
+
 # Installation
 
 This guide covers installing SkyBox and its dependencies.
@@ -36,19 +41,6 @@ brew install skybox
 ```bash [Direct Download (macOS / Linux / WSL)]
 # Install with one command (auto-detects architecture)
 curl -fsSL https://install.noorxlabs.com/skybox | bash
-```
-
-```bash [From Source]
-# Building from source requires Bun 1.0+
-
-# Install Bun (if not already installed)
-curl -fsSL https://bun.sh/install | bash
-
-# Clone and build
-git clone https://github.com/NoorXLabs/SkyBox.git
-cd SkyBox
-bun install
-bun link
 ```
 
 :::

--- a/docs/guide/quick-start.md
+++ b/docs/guide/quick-start.md
@@ -1,3 +1,8 @@
+---
+title: Quick Start
+description: Get started with SkyBox in minutes. Walk through initializing, pushing a project, starting a container, and syncing code to your remote server.
+---
+
 # Quick Start
 
 This guide walks you through the typical SkyBox workflow: from setting up your first project to developing inside a container.

--- a/docs/guide/shell-integration.md
+++ b/docs/guide/shell-integration.md
@@ -1,3 +1,8 @@
+---
+title: Shell Integration
+description: Automatically start SkyBox containers when you cd into a project directory. Configure shell hooks for Bash, Zsh, and Fish.
+---
+
 # Shell Integration
 
 Automatically start SkyBox containers when you `cd` into a project directory.

--- a/docs/guide/troubleshooting.md
+++ b/docs/guide/troubleshooting.md
@@ -1,3 +1,8 @@
+---
+title: Troubleshooting
+description: Resolve common SkyBox issues with Docker, sync, SSH connections, and container startup. Run skybox doctor for automated diagnostics.
+---
+
 # Troubleshooting
 
 Common issues and solutions for SkyBox.

--- a/docs/guide/workflows/daily-development.md
+++ b/docs/guide/workflows/daily-development.md
@@ -1,3 +1,8 @@
+---
+title: Daily Development Workflow
+description: Day-to-day patterns for working with SkyBox. Start containers, switch between projects, manage sync, and shut down cleanly.
+---
+
 # Daily Development Workflow
 
 This guide covers the day-to-day patterns for working with SkyBox: starting your work, switching between projects, and shutting down cleanly.

--- a/docs/guide/workflows/multi-machine.md
+++ b/docs/guide/workflows/multi-machine.md
@@ -1,3 +1,8 @@
+---
+title: Multi-Machine Workflow
+description: Work across multiple machines with SkyBox. Session-based coordination prevents sync conflicts when switching between laptop and desktop.
+---
+
 # Multi-Machine Workflow
 
 This guide covers working with SkyBox across multiple machines, such as a laptop and desktop. Sessions prevent sync conflicts when you switch between machines.

--- a/docs/guide/workflows/new-project.md
+++ b/docs/guide/workflows/new-project.md
@@ -1,3 +1,8 @@
+---
+title: Creating a New Project
+description: Create new SkyBox projects from scratch or bring an existing codebase. Push local code to remote servers and scaffold devcontainer configs.
+---
+
 # Creating a New Project
 
 This guide walks through creating projects with SkyBox, whether starting from scratch or bringing an existing codebase.

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,4 +1,6 @@
 ---
+title: SkyBox - Local-First Dev Containers with Remote Sync
+description: Run development containers locally with native performance. Sync code bidirectionally to remote servers. Switch between machines seamlessly.
 layout: home
 
 hero:

--- a/docs/reference/browse.md
+++ b/docs/reference/browse.md
@@ -1,3 +1,8 @@
+---
+title: skybox browse
+description: List projects available on the remote server with skybox browse. View and select remote projects for cloning.
+---
+
 # skybox browse
 
 List projects available on the remote server.

--- a/docs/reference/clone.md
+++ b/docs/reference/clone.md
@@ -1,3 +1,8 @@
+---
+title: skybox clone
+description: Clone a remote project to your local machine with skybox clone. Download and set up remote projects locally.
+---
+
 # skybox clone
 
 Clone a remote project to your local machine.

--- a/docs/reference/config.md
+++ b/docs/reference/config.md
@@ -1,3 +1,8 @@
+---
+title: skybox config
+description: View and modify SkyBox configuration with skybox config. Manage settings for remotes, defaults, and projects.
+---
+
 # skybox config
 
 View and modify SkyBox configuration.

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -1,3 +1,8 @@
+---
+title: Configuration Reference
+description: SkyBox YAML configuration file reference. Configure remotes, sync modes, ignore patterns, editors, and project-specific settings.
+---
+
 # Configuration Reference
 
 SkyBox uses a YAML configuration file to store global settings, remote server connections, sync preferences, and project-specific configurations.

--- a/docs/reference/custom-templates.md
+++ b/docs/reference/custom-templates.md
@@ -1,3 +1,8 @@
+---
+title: Custom Templates
+description: Create and manage reusable devcontainer templates in SkyBox. Store templates locally for consistent container configurations across projects.
+---
+
 # Custom Templates
 
 Create and manage reusable devcontainer templates stored locally on your machine.

--- a/docs/reference/dashboard.md
+++ b/docs/reference/dashboard.md
@@ -1,3 +1,8 @@
+---
+title: skybox dashboard
+description: Full-screen status dashboard for all SkyBox projects. Monitor containers, sync status, and resources in real time.
+---
+
 # skybox dashboard
 
 Full-screen status dashboard for all projects.

--- a/docs/reference/doctor.md
+++ b/docs/reference/doctor.md
@@ -1,3 +1,8 @@
+---
+title: skybox doctor
+description: Diagnose common issues with your SkyBox setup, dependencies, and configuration using skybox doctor.
+---
+
 # skybox doctor
 
 Diagnose common issues with your SkyBox setup, dependencies, and configuration.

--- a/docs/reference/down.md
+++ b/docs/reference/down.md
@@ -1,3 +1,8 @@
+---
+title: skybox down
+description: Stop a development container with skybox down. Shut down running containers and release local session locks.
+---
+
 # skybox down
 
 Stop a development container.

--- a/docs/reference/editor.md
+++ b/docs/reference/editor.md
@@ -1,3 +1,8 @@
+---
+title: skybox editor
+description: Change the default editor for opening projects with skybox editor. Supports VS Code, Cursor, Zed, and custom editors.
+---
+
 # skybox editor
 
 Change the default editor for opening projects.

--- a/docs/reference/encryption.md
+++ b/docs/reference/encryption.md
@@ -1,3 +1,8 @@
+---
+title: skybox encrypt
+description: Manage project encryption at rest with skybox encrypt. Encrypt and decrypt remote project files using AES-256-GCM.
+---
+
 # skybox encrypt
 
 Manage project encryption at rest.

--- a/docs/reference/hook.md
+++ b/docs/reference/hook.md
@@ -1,3 +1,8 @@
+---
+title: skybox hook
+description: Output shell hook code for auto-starting containers when entering project directories with skybox hook.
+---
+
 # skybox hook
 
 Output shell hook code for auto-starting containers when entering project directories.

--- a/docs/reference/hooks.md
+++ b/docs/reference/hooks.md
@@ -1,3 +1,8 @@
+---
+title: Hooks
+description: Run custom shell commands before and after SkyBox lifecycle operations. Configure pre/post hooks for up, down, sync, and other events.
+---
+
 # Hooks
 
 Run custom shell commands before and after lifecycle operations.

--- a/docs/reference/index.md
+++ b/docs/reference/index.md
@@ -1,3 +1,8 @@
+---
+title: Command Reference
+description: Complete reference for all SkyBox CLI commands. Manage containers, sync, remotes, projects, and configuration from the terminal.
+---
+
 # Command Reference
 
 SkyBox provides a set of commands for managing your local-first development environments with remote sync.

--- a/docs/reference/init.md
+++ b/docs/reference/init.md
@@ -1,3 +1,8 @@
+---
+title: skybox init
+description: Interactive setup wizard for configuring SkyBox. Set up remotes, SSH keys, and install dependencies with skybox init.
+---
+
 # skybox init
 
 Interactive setup wizard for configuring SkyBox.

--- a/docs/reference/list.md
+++ b/docs/reference/list.md
@@ -1,3 +1,8 @@
+---
+title: skybox list
+description: List projects available on your local machine with skybox list. View local project names, paths, and container status.
+---
+
 # skybox list
 
 List projects available on your local machine.

--- a/docs/reference/logs.md
+++ b/docs/reference/logs.md
@@ -1,3 +1,8 @@
+---
+title: skybox logs
+description: Show container or sync logs for a project with skybox logs. Stream Docker and Mutagen output for debugging.
+---
+
 # skybox logs
 
 Show container or sync logs for a project.

--- a/docs/reference/new.md
+++ b/docs/reference/new.md
@@ -1,3 +1,8 @@
+---
+title: skybox new
+description: Create a new project on the remote server with skybox new. Scaffold projects from built-in or custom templates.
+---
+
 # skybox new
 
 Create a new project on the remote server.

--- a/docs/reference/open.md
+++ b/docs/reference/open.md
@@ -1,3 +1,8 @@
+---
+title: skybox open
+description: Open editor or shell for a running container without restarting it using skybox open. Attach to active dev environments.
+---
+
 # skybox open
 
 Open editor or shell for a running container without restarting it.

--- a/docs/reference/push.md
+++ b/docs/reference/push.md
@@ -1,3 +1,8 @@
+---
+title: skybox push
+description: Push a local project to the remote server with skybox push. Upload project files via SCP to your configured remote.
+---
+
 # skybox push
 
 Push a local project to the remote server.

--- a/docs/reference/remote.md
+++ b/docs/reference/remote.md
@@ -1,3 +1,8 @@
+---
+title: skybox remote
+description: Manage remote server configurations with skybox remote. Add, edit, remove, and list configured remote servers.
+---
+
 # skybox remote
 
 Manage remote server configurations.

--- a/docs/reference/rm.md
+++ b/docs/reference/rm.md
@@ -1,3 +1,8 @@
+---
+title: skybox rm
+description: Remove a project from your local machine with skybox rm, with optional remote deletion. Clean up containers and files.
+---
+
 # skybox rm
 
 Remove a project from your local machine, with optional remote deletion.

--- a/docs/reference/shell.md
+++ b/docs/reference/shell.md
@@ -1,3 +1,8 @@
+---
+title: skybox shell
+description: Access an interactive shell inside a running container with skybox shell. Execute commands in your dev environment.
+---
+
 # skybox shell
 
 Access an interactive shell inside a running container.

--- a/docs/reference/status.md
+++ b/docs/reference/status.md
@@ -1,3 +1,8 @@
+---
+title: skybox status
+description: Show status of projects or detailed information about a specific project with skybox status. View container and sync state.
+---
+
 # skybox status
 
 Show status of projects or detailed information about a specific project.

--- a/docs/reference/up.md
+++ b/docs/reference/up.md
@@ -1,3 +1,8 @@
+---
+title: skybox up
+description: Start a development container for a project with skybox up. Launch containers with bidirectional file sync.
+---
+
 # skybox up
 
 Start a development container for a project.

--- a/docs/reference/update.md
+++ b/docs/reference/update.md
@@ -1,3 +1,8 @@
+---
+title: skybox update
+description: Check for and install SkyBox updates with skybox update. Download the latest version from GitHub releases.
+---
+
 # skybox update
 
 Check for and install SkyBox updates.

--- a/plans/IMPLEMENTATION.md
+++ b/plans/IMPLEMENTATION.md
@@ -2,7 +2,7 @@
 
 > **Version:** 0.8.0
 >
-> **Progress:** 1/18 future features | 0/18 checklist items | 0/2 release tasks
+> **Progress:** 1/19 future features | 0/18 checklist items | 0/2 release tasks
 >
 > **Completed work archived:** [`plans/archive/ARCHIVED-IMPLEMENTATION.md`](archive/ARCHIVED-IMPLEMENTATION.md)
 
@@ -61,12 +61,21 @@ Short aliases for frequently used projects (e.g., `skybox up web` instead of `sk
 - **Files:** `src/types/index.ts` (add `aliases` to config), `src/lib/project.ts` (resolve aliases)
 - **Notes:** Stored in config.yaml under `aliases` section
 
-- [ ] ### Export/Import Config
+- [ ] ### Backup & Restore (Export/Import)
 
-Share config between machines easily via encrypted export/import.
+`skybox export` / `skybox import <file>` — Export all SkyBox settings to a password-protected encrypted file for machine migration. Backs up config.yaml (remotes, projects, defaults, editor, encryption settings) and custom templates. On a new machine, `skybox import` restores everything so you can immediately `skybox clone` your projects.
 
-- **Files:** New `src/commands/export.ts`, `src/commands/import.ts`
-- **Notes:** Export as encrypted JSON/YAML bundle; import with validation
+- **Files:** New `src/commands/export.ts`, `src/commands/import.ts`, `src/lib/backup.ts`
+- **Dependencies:** None (uses existing AES-256-GCM + Argon2 from `src/lib/encryption.ts`)
+- **Notes:** Output is encrypted JSON (e.g., `skybox-backup-2026-02-09.json.enc`). Excludes ephemeral data (Mutagen binary, logs, local project files). Import validates config schema before writing and warns if config already exists. Full plan: [`plans/export-import.md`](export-import.md)
+
+- [ ] ### Git Worktree Support
+
+Allow multiple worktrees of the same repo to operate as related SkyBox projects with independent containers and sync sessions.
+
+- **Files:** `src/lib/paths.ts`, `src/lib/project.ts`, `src/lib/container.ts`, `src/lib/mutagen.ts`, `src/lib/session.ts`, `src/lib/sync-session.ts`, `src/commands/up.ts`, `src/types/index.ts`
+- **Config:** Add optional `local_path` to project config; support worktree-aware session naming
+- **Notes:** Requires decoupling project identity from filesystem path. Current architecture hardcodes `~/.skybox/Projects/<name>` as the single source of truth for local path, Mutagen session name, container label lookup, and session file location. Key changes: (1) add custom Docker label instead of relying on `devcontainer.local_folder` path matching, (2) support multiple Mutagen sessions per logical project (e.g., `skybox-myapp-main`, `skybox-myapp-feature`), (3) move session files out of synced directory to `~/.skybox/sessions/`, (4) make `resolveProjectFromCwd()` config-aware instead of purely path-based. ~15 files affected.
 
 - [ ] ### Encryption Migration & Legacy Deprecation
 
@@ -196,4 +205,4 @@ One-line description of what this feature does and why.
 
 ---
 
-*Last updated: 2026-02-07*
+*Last updated: 2026-02-09*

--- a/plans/export-import.md
+++ b/plans/export-import.md
@@ -1,0 +1,268 @@
+# Export / Import — Full SkyBox Backup & Restore
+
+> **Status:** Planned
+> **Priority:** Medium
+> **Replaces:** "Export/Import Config" entry in IMPLEMENTATION.md
+
+---
+
+## Problem
+
+When moving to a new machine, users must manually recreate their SkyBox configuration — remotes, projects, editor preferences, sync defaults, encryption settings, and custom templates. This is tedious and error-prone, especially with encrypted config values.
+
+## Solution
+
+Two commands — `skybox export` and `skybox import <file>` — that produce a single password-protected encrypted file containing all SkyBox settings. On a new machine, import restores the config so the user can immediately `skybox clone` their projects.
+
+## What Gets Backed Up
+
+| Item | Source Path | Included |
+|------|-------------|----------|
+| Config file | `~/.skybox/config.yaml` | Yes |
+| Custom templates | `~/.skybox/templates/*` | Yes |
+| Mutagen binary | `~/.skybox/bin/` | No (re-extracted on first run) |
+| Logs | `~/.skybox/logs/` | No (ephemeral) |
+| Local project files | `~/.skybox/Projects/` | No (re-cloneable from remote) |
+| Audit log | `~/.skybox/audit.log` | No (machine-specific) |
+| Update check cache | `~/.skybox/.update-check.json` | No (ephemeral) |
+| Install marker | `~/.skybox/.installed` | No (ephemeral) |
+
+## UX Design
+
+### `skybox export`
+
+```
+$ skybox export
+✔ Export passphrase: ••••••••
+✔ Confirm passphrase: ••••••••
+
+Backing up SkyBox configuration...
+  ✓ Config (3 remotes, 7 projects)
+  ✓ Custom templates (2 templates)
+
+Exported to: skybox-backup-2026-02-09.json.enc
+Restore on a new machine with: skybox import skybox-backup-2026-02-09.json.enc
+```
+
+Options:
+- `--output <path>` / `-o <path>` — Custom output file path (default: `skybox-backup-YYYY-MM-DD.json.enc` in current directory)
+
+### `skybox import <file>`
+
+```
+$ skybox import skybox-backup-2026-02-09.json.enc
+✔ Import passphrase: ••••••••
+
+Restoring SkyBox configuration...
+  ✓ Config (3 remotes, 7 projects)
+  ✓ Custom templates (2 templates)
+
+SkyBox restored. Run 'skybox clone' to pull your projects.
+```
+
+Behavior when config already exists:
+```
+⚠ SkyBox is already configured on this machine.
+? Overwrite existing config? (y/N)
+```
+
+Options:
+- `--force` / `-f` — Overwrite existing config without prompting
+
+## Encrypted File Format
+
+The export file is a JSON payload encrypted with AES-256-GCM using a password-derived key (same encryption primitives as existing `src/lib/encryption.ts`).
+
+### Plaintext structure (before encryption)
+
+```json
+{
+  "version": 1,
+  "created_at": "2026-02-09T12:00:00Z",
+  "skybox_version": "0.8.0",
+  "config": { /* full config.yaml contents as object */ },
+  "templates": {
+    "my-custom-template/devcontainer.json": "{ ... file contents ... }",
+    "my-custom-template/Dockerfile": "FROM node:20\n..."
+  }
+}
+```
+
+- `version` — Backup format version for future compatibility
+- `created_at` — ISO timestamp for user reference
+- `skybox_version` — SkyBox version that created the backup (for migration awareness)
+- `config` — The parsed config.yaml object (not raw YAML string, so it can be validated on import)
+- `templates` — Map of relative file paths to file contents within `~/.skybox/templates/`
+
+### Encrypted file structure (on disk)
+
+Uses the existing `encryptFile()` / `decryptFile()` pattern from `src/lib/encryption.ts`:
+
+```
+[salt: 32 bytes][IV: 16 bytes][encrypted JSON][auth tag: 16 bytes]
+```
+
+The salt is prepended (unlike per-config encryption where salt is stored in config.yaml) because the backup file must be self-contained.
+
+## Implementation Plan
+
+### Step 1: Add constants
+
+**File:** `src/lib/constants.ts`
+
+```typescript
+// backup file format version
+export const BACKUP_FORMAT_VERSION = 1;
+
+// default backup file name pattern
+export const BACKUP_FILE_PREFIX = "skybox-backup";
+
+// backup file extension
+export const BACKUP_FILE_EXTENSION = ".json.enc";
+
+// salt length for backup file encryption
+export const BACKUP_SALT_LENGTH = 32;
+```
+
+### Step 2: Create backup library
+
+**File:** `src/lib/backup.ts`
+
+Functions:
+- `createBackupPayload()` — Reads config + templates, assembles JSON payload
+- `encryptBackup(payload: string, passphrase: string): Buffer` — Derives key from passphrase with fresh salt, encrypts payload, returns `[salt][iv][encrypted][tag]`
+- `decryptBackup(data: Buffer, passphrase: string): string` — Extracts salt from header, derives key, decrypts and returns JSON string
+- `validateBackupPayload(payload: unknown): BackupPayload` — Validates the parsed JSON structure and config schema
+- `restoreFromBackup(payload: BackupPayload, force: boolean): void` — Writes config.yaml and template files to disk
+
+### Step 3: Create export command
+
+**File:** `src/commands/export.ts`
+
+```typescript
+export const exportCommand = async (options: { output?: string }): Promise<void> => {
+    requireLoadedConfigOrExit();
+    // 1. Prompt for passphrase (with confirmation)
+    // 2. Call createBackupPayload()
+    // 3. Call encryptBackup()
+    // 4. Write to output file
+    // 5. Print summary
+};
+```
+
+### Step 4: Create import command
+
+**File:** `src/commands/import.ts`
+
+```typescript
+export const importCommand = async (file: string, options: { force?: boolean }): Promise<void> => {
+    // 1. Check if file exists
+    // 2. Check if config already exists (prompt or --force)
+    // 3. Prompt for passphrase
+    // 4. Call decryptBackup()
+    // 5. Call validateBackupPayload()
+    // 6. Call restoreFromBackup()
+    // 7. Print summary
+};
+```
+
+### Step 5: Wire up in CLI
+
+**File:** `src/index.ts`
+
+```typescript
+import { exportCommand } from "@commands/export.ts";
+import { importCommand } from "@commands/import.ts";
+
+program
+    .command("export")
+    .description("Export SkyBox settings to an encrypted backup file")
+    .option("-o, --output <path>", "output file path")
+    .action(exportCommand);
+
+program
+    .command("import")
+    .description("Import SkyBox settings from an encrypted backup file")
+    .argument("<file>", "path to backup file")
+    .option("-f, --force", "overwrite existing config without prompting")
+    .action(importCommand);
+```
+
+### Step 6: Add types
+
+**File:** `src/types/index.ts`
+
+```typescript
+export interface BackupPayload {
+    version: number;
+    created_at: string;
+    skybox_version: string;
+    config: SkyboxConfigV2;
+    templates: Record<string, string>;
+}
+```
+
+### Step 7: Tests
+
+**File:** `tests/unit/lib/backup.test.ts`
+
+- Test `createBackupPayload()` with config + templates
+- Test `createBackupPayload()` with config only (no custom templates)
+- Test `encryptBackup()` / `decryptBackup()` round-trip
+- Test `decryptBackup()` with wrong passphrase throws
+- Test `validateBackupPayload()` accepts valid payload
+- Test `validateBackupPayload()` rejects missing fields
+- Test `validateBackupPayload()` rejects invalid config schema
+- Test `restoreFromBackup()` writes config and templates
+- Test `restoreFromBackup()` creates templates directory if missing
+
+**File:** `tests/unit/commands/export.test.ts`
+
+- Test export creates encrypted file at default path
+- Test export with `--output` custom path
+- Test export fails if not configured
+
+**File:** `tests/unit/commands/import.test.ts`
+
+- Test import restores config and templates
+- Test import prompts when config exists
+- Test import with `--force` skips prompt
+- Test import fails on nonexistent file
+- Test import fails on wrong passphrase
+- Test import fails on corrupted file
+
+## Files Changed
+
+| File | Action | Description |
+|------|--------|-------------|
+| `src/lib/constants.ts` | Modify | Add backup format constants |
+| `src/lib/backup.ts` | Create | Backup create/encrypt/decrypt/restore logic |
+| `src/commands/export.ts` | Create | Export command handler |
+| `src/commands/import.ts` | Create | Import command handler |
+| `src/index.ts` | Modify | Register export and import commands |
+| `src/types/index.ts` | Modify | Add `BackupPayload` interface |
+| `tests/unit/lib/backup.test.ts` | Create | Unit tests for backup library |
+| `tests/unit/commands/export.test.ts` | Create | Unit tests for export command |
+| `tests/unit/commands/import.test.ts` | Create | Unit tests for import command |
+
+## Dependencies
+
+None — uses existing `src/lib/encryption.ts` primitives and `argon2` (already installed).
+
+## Documentation Updates Required
+
+- `docs/reference/export.md` — New command reference page
+- `docs/reference/import.md` — New command reference page
+- `docs/.vitepress/config.ts` — Add to sidebar under Commands
+- `docs/guide/workflows/multi-machine.md` — Add backup/restore workflow section
+
+## Edge Cases
+
+- **Encrypted config values**: The config may contain `ENC[...]` values (encrypted remote passwords). These are preserved as-is in the backup. The user's original encryption passphrase is separate from the backup passphrase. On import, the `ENC[...]` values carry over and work with the same project encryption passphrase.
+- **Config migration**: If a backup was created with an older config format, the import should run the existing migration logic (`needsMigration()` / `migrateConfig()`) before saving.
+- **Large custom templates**: Templates are stored as file content strings in JSON. This is fine for devcontainer configs (small files). If a template directory contains large binaries, they'd bloat the backup. Consider adding a size warning or limit.
+- **Template directory structure**: Templates may be nested (`templates/my-template/.devcontainer/devcontainer.json`). The backup must preserve the full relative path structure.
+
+---
+
+*Last updated: 2026-02-09*


### PR DESCRIPTION
## Summary

Improves documentation discoverability through SEO enhancements and removes the unsupported "From Source" installation method. Adds VitePress meta tags for search engines and social media sharing, plus introduces the backup/restore feature plan.

## What Changed

- Added YAML frontmatter (`title`, `description`) to all 36 documentation pages for SEO
- Enhanced VitePress config with Open Graph, Twitter Card meta tags, canonical URLs, and per-page metadata via `transformHead()` hook
- Removed "From Source" installation method from installation guide
- Added `plans/export-import.md` with backup/restore feature specification
- Updated `plans/IMPLEMENTATION.md` with new feature entry and progress tracking

## Testing Evidence

- [x] `bun run check:ci` — Passed (Biome linting/formatting)
- [x] `bun run typecheck` — Passed (TypeScript type checking)
- [x] No runtime tests needed (docs-only changes)

## Documentation Impact

- [x] Docs updated (all pages in `docs/guide/` and `docs/reference/` + VitePress config)

## Changelog Impact

- [x] No changelog update needed (docs-only changes)

## Risk and Rollback

No runtime risk. These are documentation-only changes. To rollback: revert the commit.

## Linked Issues

None