### PR TITLE
feat: multi-select down, escapeRemotePath fixes, container flag fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,11 +10,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - **Open Source Contribution Framework**: Added GitHub issue forms (bug/feature/docs), pull request template, governance docs (`CONTRIBUTING.md`, `CODE_OF_CONDUCT.md`, `SECURITY.md`, `SUPPORT.md`), CODEOWNERS, and label taxonomy/automation workflows for triage and path-based PR auto-labeling.
+- **Multi-Select Down**: `skybox down` now supports checkbox multi-select when run without arguments, with batch stop and batch cleanup prompts
 
 ### Changed
 
+- **Documentation SEO**: Added frontmatter metadata, Open Graph/Twitter Card meta tags, canonical URLs, and social sharing images across all documentation pages
+- Removed "From Source" installation method from documentation; updated devcontainer CLI link to official install script
 - **Internal Refactor**: Consolidated shared sync finalization and start-container prompt flows across `clone`, `push`, and `new` for consistency, without changing CLI behavior.
 - **Internal Refactor**: Reduced duplication in encryption/archive/download internals and test context lifecycle helpers, with no user-facing behavior changes.
+
+### Fixed
+
+- Remaining `escapeShellArg()` calls on remote paths replaced with `escapeRemotePath()` across clone, config-devcontainer, push, rm, ownership, remote-encryption, and remote modules
+- Incorrect `--rebuild-if-exists` flag in container rebuild replaced with correct `--remove-existing-container`
 
 ## [0.8.0] - 2026-02-07
 

--- a/plans/IMPLEMENTATION.md
+++ b/plans/IMPLEMENTATION.md
@@ -2,7 +2,7 @@
 
 > **Version:** 0.8.0
 >
-> **Progress:** 1/19 future features | 0/18 checklist items | 0/2 release tasks
+> **Progress:** 2/19 future features | 0/18 checklist items | 1/1 release tasks
 >
 > **Completed work archived:** [`plans/archive/ARCHIVED-IMPLEMENTATION.md`](archive/ARCHIVED-IMPLEMENTATION.md)
 
@@ -21,7 +21,7 @@
 
 ## Future Features — High Priority
 
-- [ ] ### Create Template Repositories
+- [x] ### Create Template Repositories *(Completed in v0.8.0)*
 
 Built-in templates (Node.js, Bun, Python, Go) reference non-existent GitHub repos at `skybox-templates/*-starter`. Either create these repos or replace with working alternatives (e.g., official devcontainer templates).
 
@@ -183,8 +183,7 @@ bash/zsh/fish completion scripts for all commands and options.
 
 ## Release Preparation
 
-- [ ] npm registry publication configured
-- [ ] Homebrew formula updated
+- [x] Homebrew formula updated
 
 ---
 

--- a/plans/down-multi-select.md
+++ b/plans/down-multi-select.md
@@ -1,0 +1,67 @@
+# Design: Multi-Select for `skybox down`
+
+**Date:** 2026-02-09
+**Status:** Approved
+
+## Problem
+
+`skybox down` only allows stopping one project at a time (single-select rawlist prompt). `skybox up` already supports multi-select via checkbox. Users should be able to select multiple projects to stop in one invocation.
+
+## Design
+
+### Project Resolution
+
+| Invocation | Behavior |
+|---|---|
+| `skybox down myapp` | Single project (no change) |
+| `skybox down` (inside project dir) | Single project from CWD (no change) |
+| `skybox down` (no arg, no CWD) | **Checkbox multi-select** (new) |
+| `skybox down --all` | All projects (no change) |
+
+### Execution Flow
+
+**Phase 1 — Stop each project sequentially:**
+For each selected project:
+1. Run pre-down hooks
+2. Flush sync
+3. Stop container
+4. Handle encryption (prompt passphrase individually per project)
+5. Delete session file
+6. Run post-down hooks
+
+**Phase 2 — Batch cleanup (ask once, apply to all):**
+After all projects stopped:
+1. "Remove containers for all stopped projects?" → yes/no
+2. If yes: "Also remove local project files?" + confirmation → yes/no
+3. If no cleanup: "Pause background sync for all stopped projects?" → yes/no
+
+### Flag Behavior
+
+- `--cleanup`: Skip cleanup prompt, apply removal to all
+- `--no-prompt`: Skip all prompts (just stop, no cleanup)
+- `--force`: Continue past individual failures
+- `--all`: Stop all local projects (existing behavior)
+
+### Single Project Path
+
+When only one project is resolved (explicit arg, CWD, or single checkbox selection), the existing single-project flow runs unchanged — including per-project interactive prompts.
+
+## Implementation
+
+### Files Changed
+
+Only `src/commands/down.ts`:
+
+1. **`resolveProjectsForDown()`** — New function. Uses `checkbox` from `@inquirer/prompts` for multi-select when no arg/CWD match. Returns `string[]`.
+2. **`stopSingleProject()`** — Extracted from `downCommand()`. Core stop logic: hooks, sync flush, container stop, encryption, session delete.
+3. **`handleBatchCleanup()`** — New function. Asks cleanup/remove/pause questions once, applies to all stopped projects.
+4. **`downCommand()`** — Refactored as orchestrator: resolve projects → single path or multi path.
+
+### No Changes To
+
+- `src/types/index.ts` — `DownOptions` already has all needed fields
+- `src/lib/project.ts` — `resolveSingleProject()` untouched; new resolution logic lives in `down.ts`
+
+## Documentation Updates Required
+
+- `docs/reference/` — Update `down` command docs to mention multi-select

--- a/src/commands/clone.ts
+++ b/src/commands/clone.ts
@@ -19,7 +19,7 @@ import { getLocalProjects } from "@lib/project.ts";
 import { finalizeProjectSync } from "@lib/project-sync.ts";
 import { validateProjectName } from "@lib/projectTemplates.ts";
 import { checkRemoteProjectExists } from "@lib/remote.ts";
-import { escapeShellArg } from "@lib/shell.ts";
+import { escapeRemotePath } from "@lib/shell.ts";
 import { runRemoteCommand } from "@lib/ssh.ts";
 import {
 	confirmDestructiveAction,
@@ -163,7 +163,7 @@ export const cloneSingleProject = async (
 	const encArchivePath = `${remotePath}/${project}.tar.enc`;
 	const encCheck = await runRemoteCommand(
 		host,
-		`test -f ${escapeShellArg(encArchivePath)} && echo "ENCRYPTED" || echo "PLAIN"`,
+		`test -f ${escapeRemotePath(encArchivePath)} && echo "ENCRYPTED" || echo "PLAIN"`,
 	);
 
 	if (encCheck.stdout?.includes("ENCRYPTED")) {

--- a/src/commands/config-devcontainer.ts
+++ b/src/commands/config-devcontainer.ts
@@ -11,7 +11,7 @@ import {
 } from "@lib/constants.ts";
 import { getErrorMessage } from "@lib/errors.ts";
 import { getProjectPath, projectExists } from "@lib/project.ts";
-import { escapeShellArg } from "@lib/shell.ts";
+import { escapeRemotePath, escapeShellArg } from "@lib/shell.ts";
 import { runRemoteCommand } from "@lib/ssh.ts";
 import { selectTemplate, writeDevcontainerConfig } from "@lib/templates.ts";
 import { dryRun, error, info, isDryRun, spinner, success } from "@lib/ui.ts";
@@ -144,7 +144,7 @@ const pushDevcontainerToRemote = async (
 		const encoded = Buffer.from(configContent).toString("base64");
 		const result = await runRemoteCommand(
 			remoteHost,
-			`mkdir -p ${escapeShellArg(`${remotePath}/${DEVCONTAINER_DIR_NAME}`)} && echo ${escapeShellArg(encoded)} | base64 -d > ${escapeShellArg(`${remotePath}/${DEVCONTAINER_DIR_NAME}/${DEVCONTAINER_CONFIG_NAME}`)}`,
+			`mkdir -p ${escapeRemotePath(`${remotePath}/${DEVCONTAINER_DIR_NAME}`)} && echo ${escapeShellArg(encoded)} | base64 -d > ${escapeRemotePath(`${remotePath}/${DEVCONTAINER_DIR_NAME}/${DEVCONTAINER_CONFIG_NAME}`)}`,
 			remote.key ?? undefined,
 		);
 		if (result.success) {

--- a/src/commands/down.ts
+++ b/src/commands/down.ts
@@ -6,7 +6,7 @@ import {
 	getRemoteHost,
 	getRemotePath,
 } from "@commands/remote.ts";
-import { password } from "@inquirer/prompts";
+import { checkbox, password } from "@inquirer/prompts";
 import { AuditActions, logAuditEvent } from "@lib/audit.ts";
 import { requireConfig, saveConfig } from "@lib/config.ts";
 import { MAX_PASSPHRASE_ATTEMPTS } from "@lib/constants.ts";
@@ -24,7 +24,7 @@ import {
 	getLocalProjects,
 	getProjectPath,
 	projectExists,
-	resolveSingleProject,
+	resolveProjectFromCwd,
 } from "@lib/project.ts";
 import {
 	createRemoteArchiveTarget,
@@ -122,56 +122,59 @@ const handleEncryption = async (
 	return false;
 };
 
-// stop a project container, flush sync, optionally encrypt, and clean up
-export const downCommand = async (
+// resolve which project(s) to operate on from argument, cwd, or multi-select prompt.
+// returns an array of project names, or null if resolution failed.
+const resolveProjectsForDown = async (
 	projectArg: string | undefined,
 	options: DownOptions,
-): Promise<void> => {
-	// Batch mode: stop all local projects
-	if (options.all) {
-		const projects = getLocalProjects();
-		if (projects.length === 0) {
-			info("No local projects found.");
-			return;
-		}
-		info(`Stopping ${projects.length} projects...`);
-		let succeeded = 0;
-		let failed = 0;
-		for (const project of projects) {
-			try {
-				header(`\n${project}`);
-				await downCommand(project, { ...options, all: false });
-				succeeded++;
-			} catch (err) {
-				failed++;
-				error(`Failed: ${getErrorMessage(err)}`);
-			}
-		}
-		info(`\nDone: ${succeeded} stopped, ${failed} failed.`);
-		return;
+): Promise<string[] | null> => {
+	// Explicit argument: single project
+	if (projectArg) {
+		return [projectArg];
 	}
 
-	const config = requireConfig();
+	// Try to resolve from cwd
+	const cwdProject = resolveProjectFromCwd() ?? undefined;
+	if (cwdProject) {
+		return [cwdProject];
+	}
 
-	const resolution = await resolveSingleProject({
-		projectArg,
-		noPrompt: options.noPrompt,
-		promptMessage: "Select a project to stop:",
-	});
-	if ("reason" in resolution) {
-		if (resolution.reason === "no-projects") {
-			error("No local projects found.");
-			process.exit(1);
-		}
+	// No argument and not in a project dir — prompt with checkbox
+	const projects = getLocalProjects();
+
+	if (projects.length === 0) {
+		error("No local projects found.");
+		return null;
+	}
+
+	if (options.noPrompt) {
 		error("No project specified and --no-prompt is set.");
-		process.exit(1);
+		return null;
 	}
-	const project = resolution.project;
 
-	// Verify project exists locally
+	const selected = await checkbox({
+		message: "Select project(s) to stop:",
+		choices: projects.map((p) => ({ name: p, value: p })),
+	});
+
+	if (selected.length === 0) {
+		error("No projects selected.");
+		return null;
+	}
+
+	return selected;
+};
+
+// stop a single project: hooks, sync flush, container stop, encryption, session delete.
+// returns true if the project was stopped successfully.
+const stopSingleProject = async (
+	project: string,
+	config: SkyboxConfigV2,
+	options: DownOptions,
+): Promise<boolean> => {
 	if (!projectExists(project)) {
 		error(`Project '${project}' not found locally.`);
-		process.exit(1);
+		return false;
 	}
 
 	const projectPath = getProjectPath(project);
@@ -191,7 +194,7 @@ export const downCommand = async (
 		if (projectConfig?.hooks) {
 			dryRun(`Would run post-down hooks for '${project}'`);
 		}
-		return;
+		return true;
 	}
 
 	// Run pre-down hooks
@@ -202,7 +205,6 @@ export const downCommand = async (
 
 	// Check container status
 	const containerStatus = await getContainerStatus(projectPath);
-	const containerInfo = await getContainerInfo(projectPath);
 
 	if (containerStatus === ContainerStatus.NotFound) {
 		info("No container found for this project.");
@@ -225,7 +227,7 @@ export const downCommand = async (
 				stopSpin.fail("Failed to stop container");
 				error(stopResult.error || "Unknown error");
 				if (!options.force) {
-					process.exit(1);
+					return false;
 				}
 			} else {
 				stopSpin.succeed("Container stopped");
@@ -244,6 +246,168 @@ export const downCommand = async (
 		deleteSession(projectPath);
 		success("Session ended");
 	}
+
+	// Run post-down hooks
+	if (projectConfig?.hooks) {
+		await runHooks("post-down", projectConfig.hooks, projectPath);
+	}
+
+	logAuditEvent(AuditActions.DOWN, { project });
+	return true;
+};
+
+// handle cleanup prompts and actions for a set of stopped projects.
+// asks once, applies to all.
+const handleBatchCleanup = async (
+	projects: string[],
+	config: SkyboxConfigV2,
+	options: DownOptions,
+): Promise<void> => {
+	// Determine which projects have containers to clean up
+	const projectsWithContainers: Array<{
+		project: string;
+		projectPath: string;
+	}> = [];
+	for (const project of projects) {
+		const projectPath = getProjectPath(project);
+		const containerInfo = await getContainerInfo(projectPath);
+		if (containerInfo) {
+			projectsWithContainers.push({ project, projectPath });
+		}
+	}
+
+	// Ask about cleanup (once for all)
+	let shouldCleanup = options.cleanup;
+
+	if (
+		!options.noPrompt &&
+		shouldCleanup === undefined &&
+		projectsWithContainers.length > 0
+	) {
+		const { cleanup } = await inquirer.prompt([
+			{
+				type: "confirm",
+				name: "cleanup",
+				message: `Remove containers for ${projectsWithContainers.length} project(s) to free up resources?`,
+				default: false,
+			},
+		]);
+		shouldCleanup = cleanup;
+	}
+
+	if (shouldCleanup && projectsWithContainers.length > 0) {
+		for (const { project, projectPath } of projectsWithContainers) {
+			const removeSpin = spinner(`Removing container for '${project}'...`);
+			const removeResult = await removeContainer(projectPath, {
+				removeVolumes: true,
+			});
+			if (removeResult.success) {
+				removeSpin.succeed(`Container removed for '${project}'`);
+			} else {
+				removeSpin.fail(`Failed to remove container for '${project}'`);
+				warn(removeResult.error || "Unknown error");
+			}
+		}
+	}
+
+	// Ask about local files cleanup (once for all)
+	let shouldRemoveLocal = false;
+
+	if (!options.noPrompt && shouldCleanup && projectsWithContainers.length > 0) {
+		const { removeLocal } = await inquirer.prompt([
+			{
+				type: "confirm",
+				name: "removeLocal",
+				message: `Also remove local project files for ${projectsWithContainers.length} project(s) with containers? (Remote copies will be preserved)`,
+				default: false,
+			},
+		]);
+		shouldRemoveLocal = removeLocal;
+
+		if (shouldRemoveLocal) {
+			const projectNames = projectsWithContainers
+				.map(({ project }) => project)
+				.join(", ");
+			const { confirmRemove } = await inquirer.prompt([
+				{
+					type: "confirm",
+					name: "confirmRemove",
+					message: `Are you sure? This will delete local files for: ${projectNames}`,
+					default: false,
+				},
+			]);
+			shouldRemoveLocal = confirmRemove;
+		}
+	}
+
+	if (shouldRemoveLocal) {
+		for (const { project, projectPath } of projectsWithContainers) {
+			// Pause sync first
+			const syncSpin = spinner(`Stopping sync for '${project}'...`);
+			await pauseSync(project);
+			syncSpin.succeed(`Sync paused for '${project}'`);
+
+			// Remove local files
+			const rmSpin = spinner(`Removing local files for '${project}'...`);
+			try {
+				if (existsSync(projectPath)) {
+					rmSync(projectPath, { recursive: true });
+				}
+				rmSpin.succeed(`Local files removed for '${project}'`);
+
+				const projectRemoteInfo = getProjectRemote(project, config);
+
+				if (config.projects?.[project]) {
+					delete config.projects[project];
+					saveConfig(config);
+				}
+
+				if (projectRemoteInfo) {
+					const host = getRemoteHost(projectRemoteInfo.remote);
+					const remotePath = getRemotePath(projectRemoteInfo.remote, project);
+					info(`Remote copy preserved at ${host}:${remotePath}`);
+				}
+				info(`Run 'skybox clone ${project}' to restore locally.`);
+			} catch (err: unknown) {
+				rmSpin.fail(`Failed to remove local files for '${project}'`);
+				error(getErrorMessage(err));
+			}
+		}
+	} else if (!shouldCleanup) {
+		// Ask about pausing sync (once for all)
+		if (!options.noPrompt) {
+			const { pauseSyncSession } = await inquirer.prompt([
+				{
+					type: "confirm",
+					name: "pauseSyncSession",
+					message: "Pause background sync for all stopped projects?",
+					default: false,
+				},
+			]);
+
+			if (pauseSyncSession) {
+				for (const project of projects) {
+					const syncSpin = spinner(`Pausing sync for '${project}'...`);
+					const pauseResult = await pauseSync(project);
+					if (pauseResult.success) {
+						syncSpin.succeed(`Sync paused for '${project}'`);
+					} else {
+						syncSpin.warn(`Could not pause sync for '${project}'`);
+					}
+				}
+			}
+		}
+	}
+};
+
+// handle cleanup prompts and actions for a single project (original interactive flow).
+const handleSingleCleanup = async (
+	project: string,
+	config: SkyboxConfigV2,
+	options: DownOptions,
+): Promise<void> => {
+	const projectPath = getProjectPath(project);
+	const containerInfo = await getContainerInfo(projectPath);
 
 	// Ask about cleanup
 	let shouldCleanup = options.cleanup;
@@ -301,11 +465,6 @@ export const downCommand = async (
 		}
 	}
 
-	// Run post-down hooks before potential directory deletion
-	if (projectConfig?.hooks) {
-		await runHooks("post-down", projectConfig.hooks, projectPath);
-	}
-
 	if (shouldRemoveLocal) {
 		// Pause sync first
 		const syncSpin = spinner("Stopping sync...");
@@ -320,10 +479,8 @@ export const downCommand = async (
 			}
 			rmSpin.succeed("Local files removed");
 
-			// Get remote info for the info message
 			const projectRemoteInfo = getProjectRemote(project, config);
 
-			// Optionally remove from config
 			if (config.projects?.[project]) {
 				delete config.projects[project];
 				saveConfig(config);
@@ -339,9 +496,9 @@ export const downCommand = async (
 			rmSpin.fail("Failed to remove local files");
 			error(getErrorMessage(err));
 		}
-	} else {
-		// Just pause sync if not removing
-		if (!shouldCleanup) {
+	} else if (!shouldCleanup) {
+		// Ask about pausing sync
+		if (!options.noPrompt) {
 			const { pauseSyncSession } = await inquirer.prompt([
 				{
 					type: "confirm",
@@ -363,6 +520,89 @@ export const downCommand = async (
 		}
 	}
 
-	logAuditEvent(AuditActions.DOWN, { project });
 	success(`'${project}' stopped.`);
+};
+
+// stop project containers, flush sync, optionally encrypt, and clean up
+export const downCommand = async (
+	projectArg: string | undefined,
+	options: DownOptions,
+): Promise<void> => {
+	// Batch mode: stop all local projects
+	if (options.all) {
+		const projects = getLocalProjects();
+		if (projects.length === 0) {
+			info("No local projects found.");
+			return;
+		}
+		info(`Stopping ${projects.length} projects...`);
+		const config = requireConfig();
+		let succeeded = 0;
+		let failed = 0;
+		const stoppedProjects: string[] = [];
+		for (const project of projects) {
+			try {
+				header(`\n${project}`);
+				const ok = await stopSingleProject(project, config, options);
+				if (ok) {
+					succeeded++;
+					stoppedProjects.push(project);
+				} else {
+					failed++;
+				}
+			} catch (err) {
+				failed++;
+				error(`Failed: ${getErrorMessage(err)}`);
+			}
+		}
+		if (stoppedProjects.length > 0) {
+			await handleBatchCleanup(stoppedProjects, config, options);
+		}
+		info(`\nDone: ${succeeded} stopped, ${failed} failed.`);
+		return;
+	}
+
+	const config = requireConfig();
+
+	// Resolve project(s)
+	const resolvedProjects = await resolveProjectsForDown(projectArg, options);
+	if (!resolvedProjects) {
+		process.exit(1);
+	}
+
+	// Single project: use original interactive flow
+	if (resolvedProjects.length === 1) {
+		const project = resolvedProjects[0];
+		const ok = await stopSingleProject(project, config, options);
+		if (!ok && !options.force) {
+			process.exit(1);
+		}
+		await handleSingleCleanup(project, config, options);
+		return;
+	}
+
+	// Multi-project: stop each, then batch cleanup
+	let succeeded = 0;
+	let failed = 0;
+	const stoppedProjects: string[] = [];
+	for (const project of resolvedProjects) {
+		try {
+			const ok = await stopSingleProject(project, config, options);
+			if (ok) {
+				succeeded++;
+				stoppedProjects.push(project);
+			} else {
+				failed++;
+			}
+		} catch (err) {
+			failed++;
+			error(`Failed to stop '${project}': ${getErrorMessage(err)}`);
+		}
+	}
+
+	if (stoppedProjects.length > 0) {
+		await handleBatchCleanup(stoppedProjects, config, options);
+	}
+
+	info(`\nDone: ${succeeded} stopped, ${failed} failed.`);
 };

--- a/src/commands/encrypt.ts
+++ b/src/commands/encrypt.ts
@@ -19,6 +19,7 @@ import {
 	error,
 	info,
 	isDryRun,
+	promptPassphraseWithConfirmation,
 	spinner,
 	success,
 	warn,
@@ -107,15 +108,8 @@ const enableEncryption = async (project?: string): Promise<void> => {
 		return;
 	}
 
-	// Prompt for passphrase
-	const passphrase = await password({
-		message: "Enter encryption passphrase:",
-	});
-
-	if (!passphrase) {
-		error("Passphrase is required.");
-		return;
-	}
+	// Prompt for passphrase with confirmation (not stored — user must remember it)
+	await promptPassphraseWithConfirmation("Enter encryption passphrase:");
 
 	// Generate salt and save
 	const salt = randomBytes(16).toString("hex");

--- a/src/commands/push.ts
+++ b/src/commands/push.ts
@@ -17,7 +17,7 @@ import { getProjectsDir } from "@lib/paths.ts";
 import { finalizeProjectSync } from "@lib/project-sync.ts";
 import { validateProjectName } from "@lib/projectTemplates.ts";
 import { checkRemoteProjectExists } from "@lib/remote.ts";
-import { escapeShellArg } from "@lib/shell.ts";
+import { escapeRemotePath } from "@lib/shell.ts";
 import { runRemoteCommand } from "@lib/ssh.ts";
 import {
 	confirmDestructiveAction,
@@ -180,7 +180,7 @@ export const pushCommand = async (
 		}
 
 		// Remove remote directory
-		await runRemoteCommand(host, `rm -rf ${escapeShellArg(remotePath)}`);
+		await runRemoteCommand(host, `rm -rf ${escapeRemotePath(remotePath)}`);
 	} else {
 		checkSpin.succeed("Remote path available");
 	}
@@ -189,7 +189,7 @@ export const pushCommand = async (
 	const mkdirSpin = spinner("Creating remote directory...");
 	const mkdirResult = await runRemoteCommand(
 		host,
-		`mkdir -p ${escapeShellArg(remotePath)}`,
+		`mkdir -p ${escapeRemotePath(remotePath)}`,
 	);
 
 	if (!mkdirResult.success) {

--- a/src/commands/rm.ts
+++ b/src/commands/rm.ts
@@ -25,7 +25,7 @@ import {
 } from "@lib/project.ts";
 import { validateProjectName } from "@lib/projectTemplates.ts";
 import { deleteSession, readSession } from "@lib/session.ts";
-import { escapeShellArg } from "@lib/shell.ts";
+import { escapeRemotePath } from "@lib/shell.ts";
 import { runRemoteCommand } from "@lib/ssh.ts";
 import {
 	confirmDestructiveAction,
@@ -142,7 +142,7 @@ const deleteProjectFromRemote = async (
 	try {
 		const result = await runRemoteCommand(
 			host,
-			`rm -rf ${escapeShellArg(remotePath)}`,
+			`rm -rf ${escapeRemotePath(remotePath)}`,
 			remote.key,
 		);
 

--- a/src/lib/container.ts
+++ b/src/lib/container.ts
@@ -171,7 +171,7 @@ export const startContainer = async (
 	const args = ["up", "--workspace-folder", projectPath];
 
 	if (options?.rebuild) {
-		args.push("--rebuild-if-exists");
+		args.push("--remove-existing-container");
 	}
 
 	try {

--- a/src/lib/ownership.ts
+++ b/src/lib/ownership.ts
@@ -2,7 +2,7 @@
 
 import { hostname, userInfo } from "node:os";
 import { OWNERSHIP_FILE_NAME } from "@lib/constants.ts";
-import { escapeShellArg } from "@lib/shell.ts";
+import { escapeRemotePath, escapeShellArg } from "@lib/shell.ts";
 import { runRemoteCommand } from "@lib/ssh.ts";
 import { validateRemotePath } from "@lib/validation.ts";
 import type {
@@ -66,7 +66,7 @@ export const getOwnershipStatus = async (
 		return { hasOwner: false };
 	}
 	const ownershipFile = `${projectPath}/${OWNERSHIP_FILE_NAME}`;
-	const command = `cat ${escapeShellArg(ownershipFile)} 2>/dev/null`;
+	const command = `cat ${escapeRemotePath(ownershipFile)} 2>/dev/null`;
 
 	const result = await runRemoteCommand(host, command);
 
@@ -104,7 +104,7 @@ export const setOwnership = async (
 	const jsonBase64 = Buffer.from(json).toString("base64");
 
 	// Write ownership file using base64 decode (avoids shell escaping issues)
-	const command = `echo ${escapeShellArg(jsonBase64)} | base64 -d > ${escapeShellArg(ownershipFile)}`;
+	const command = `echo ${escapeShellArg(jsonBase64)} | base64 -d > ${escapeRemotePath(ownershipFile)}`;
 	const result = await runRemoteCommand(host, command);
 
 	if (!result.success) {

--- a/src/lib/remote-encryption.ts
+++ b/src/lib/remote-encryption.ts
@@ -64,7 +64,7 @@ export const remoteArchiveExists = async (
 ): Promise<boolean> => {
 	const checkResult = await runRemoteCommand(
 		target.host,
-		`test -f ${escapeShellArg(target.remoteArchivePath)} && echo "EXISTS" || echo "NOT_FOUND"`,
+		`test -f ${escapeRemotePath(target.remoteArchivePath)} && echo "EXISTS" || echo "NOT_FOUND"`,
 	);
 	return checkResult.success && checkResult.stdout?.includes("EXISTS") === true;
 };
@@ -91,7 +91,7 @@ export const decryptRemoteArchive = async (
 		onProgress?.("Extracting...");
 		const extractResult = await runRemoteCommand(
 			target.host,
-			`cd ${escapeShellArg(target.remotePath)} && tar xf ${escapeShellArg(remoteTarName)} && rm -f ${escapeShellArg(remoteTarName)} ${escapeShellArg(target.archiveName)}`,
+			`cd ${escapeRemotePath(target.remotePath)} && tar xf ${escapeShellArg(remoteTarName)} && rm -f ${escapeShellArg(remoteTarName)} ${escapeShellArg(target.archiveName)}`,
 		);
 
 		if (!extractResult.success) {

--- a/src/lib/remote.ts
+++ b/src/lib/remote.ts
@@ -1,6 +1,6 @@
 // operations for interacting with remote servers.
 
-import { escapeShellArg } from "@lib/shell.ts";
+import { escapeRemotePath } from "@lib/shell.ts";
 import { runRemoteCommand } from "@lib/ssh.ts";
 import { validateRemoteProjectPath } from "@lib/validation.ts";
 
@@ -17,7 +17,7 @@ export const checkRemoteProjectExists = async (
 	const fullPath = `${basePath}/${project}`;
 	const result = await runRemoteCommand(
 		host,
-		`test -d ${escapeShellArg(fullPath)} && echo "EXISTS" || echo "NOT_FOUND"`,
+		`test -d ${escapeRemotePath(fullPath)} && echo "EXISTS" || echo "NOT_FOUND"`,
 	);
 	return result.stdout?.includes("EXISTS") ?? false;
 };

--- a/src/lib/ui.ts
+++ b/src/lib/ui.ts
@@ -1,4 +1,5 @@
 // terminal UI helpers: colored output, spinners, headers.
+import { password } from "@inquirer/prompts";
 import chalk from "chalk";
 import { program } from "commander";
 import inquirer from "inquirer";
@@ -90,6 +91,30 @@ export const confirmDestructiveAction = async (options: {
 	}
 
 	return true;
+};
+
+// prompt for a passphrase with confirmation (re-enter to verify match).
+// loops until both entries match. rejects empty passphrases.
+export const promptPassphraseWithConfirmation = async (
+	message: string,
+): Promise<string> => {
+	for (;;) {
+		const passphrase = await password({ message });
+
+		if (!passphrase) {
+			warn("Passphrase cannot be empty. Try again.");
+			continue;
+		}
+
+		const confirmation = await password({ message: "Confirm passphrase:" });
+
+		if (passphrase !== confirmation) {
+			warn("Passphrases do not match. Try again.");
+			continue;
+		}
+
+		return passphrase;
+	}
 };
 
 // check if --dry-run flag was passed to the CLI


### PR DESCRIPTION
## Summary

- **Multi-select `skybox down`**: Adds checkbox multi-select when `skybox down` is run without arguments, with batch stop and batch cleanup prompts (ask once, apply to all)
- **Security fix**: Replaces remaining `escapeShellArg()` calls with `escapeRemotePath()` on remote paths across `clone`, `config-devcontainer`, `push`, `rm`, `ownership`, `remote-encryption`, and `remote` modules
- **Bug fix**: Corrects incorrect `--rebuild-if-exists` devcontainer flag to `--remove-existing-container`
- **Shared helper**: Adds `promptPassphraseWithConfirmation()` to `ui.ts` for reusable passphrase double-entry
- **Docs**: Updates CLAUDE.md (reorganized gotchas, added missing scripts/files/env vars), changelog, and implementation tracker

## Test plan

- [x] `bun run typecheck` passes
- [x] `bun run check` passes (Biome lint + format)
- [x] `bun run test` passes (484 unit tests, 0 failures)
- [ ] Manual test: `skybox down` without args shows checkbox multi-select
- [ ] Manual test: multi-select stop + batch cleanup prompts work correctly
- [ ] Manual test: single-project `skybox down` retains original interactive flow