### PR TITLE
feat(cli): add full docs URL to top-level help

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -32,6 +32,8 @@ import chalk from "chalk";
 import { program } from "commander";
 import pkg from "../package.json";
 
+const DOCS_URL = "https://skybox.noorxlabs.com";
+
 // Install graceful shutdown handlers early
 installShutdownHandlers();
 
@@ -57,7 +59,8 @@ program
 	.name("skybox")
 	.description("Local-first dev containers with remote sync")
 	.version(pkg.version, "-v, --version")
-	.option("--dry-run", "Preview commands without executing them");
+	.option("--dry-run", "Preview commands without executing them")
+	.addHelpText("after", `\nFull docs: ${DOCS_URL}`);
 
 program
 	.command("init")

--- a/tests/unit/commands/dry-run-global.test.ts
+++ b/tests/unit/commands/dry-run-global.test.ts
@@ -8,6 +8,7 @@ describe("global --dry-run option", () => {
 		const output = result.stdout.toString();
 		expect(output).toContain("--dry-run");
 		expect(output).toContain("Preview commands without executing them");
+		expect(output).toContain("Full docs: https://skybox.noorxlabs.com");
 	});
 
 	test("--dry-run is not rejected as unknown option", () => {


### PR DESCRIPTION
## Summary
- append a `Full docs` URL to Commander top-level help output
- make the URL reusable via a `DOCS_URL` constant in CLI entrypoint
- add unit coverage asserting the docs link is present in `--help` output

## Validation
- bun test tests/unit/commands/dry-run-global.test.ts
- pre-commit hooks passed (biome check, typecheck, full unit test suite)
