### PR TITLE
refactor: simplify duplicated helpers and centralize reusable types

### DIFF
--- a/src/commands/push.ts
+++ b/src/commands/push.ts
@@ -9,7 +9,7 @@ import {
 } from "@commands/remote.ts";
 import { upCommand } from "@commands/up.ts";
 import { AuditActions, logAuditEvent } from "@lib/audit.ts";
-import { configExists, loadConfig } from "@lib/config.ts";
+import { requireConfig } from "@lib/config.ts";
 import { offerStartContainer } from "@lib/container-start.ts";
 import { getErrorMessage } from "@lib/errors.ts";
 import { checkWriteAuthorization, setOwnership } from "@lib/ownership.ts";
@@ -55,16 +55,7 @@ export const pushCommand = async (
 		process.exit(1);
 	}
 
-	if (!configExists()) {
-		error("skybox not configured. Run 'skybox init' first.");
-		process.exit(1);
-	}
-
-	const config = loadConfig();
-	if (!config) {
-		error("Failed to load config.");
-		process.exit(1);
-	}
+	const config = requireConfig();
 
 	// Resolve path
 	const absolutePath = resolve(sourcePath);

--- a/src/lib/atomic-write.ts
+++ b/src/lib/atomic-write.ts
@@ -1,0 +1,50 @@
+import {
+	existsSync,
+	mkdirSync,
+	renameSync,
+	unlinkSync,
+	writeFileSync,
+} from "node:fs";
+import { basename, dirname, join } from "node:path";
+
+interface AtomicWriteOptions {
+	dirMode?: number;
+	fileMode?: number;
+}
+
+// atomically write a file by writing to a temp file and renaming into place.
+// ensures parent directory exists and cleans up temp files on failure.
+export const writeFileAtomic = (
+	filePath: string,
+	content: string,
+	options: AtomicWriteOptions = {},
+): void => {
+	const dir = dirname(filePath);
+	if (!existsSync(dir)) {
+		if (options.dirMode !== undefined) {
+			mkdirSync(dir, { recursive: true, mode: options.dirMode });
+		} else {
+			mkdirSync(dir, { recursive: true });
+		}
+	}
+
+	const tempPath = join(dir, `.${basename(filePath)}.tmp.${process.pid}`);
+	try {
+		if (options.fileMode !== undefined) {
+			writeFileSync(tempPath, content, {
+				encoding: "utf-8",
+				mode: options.fileMode,
+			});
+		} else {
+			writeFileSync(tempPath, content, "utf-8");
+		}
+		renameSync(tempPath, filePath);
+	} catch (error) {
+		try {
+			unlinkSync(tempPath);
+		} catch {
+			// ignore cleanup errors
+		}
+		throw error;
+	}
+};

--- a/src/lib/download.ts
+++ b/src/lib/download.ts
@@ -68,31 +68,26 @@ export const getMutagenChecksumUrl = (version: string): string => {
 	return `https://github.com/${MUTAGEN_REPO}/releases/download/v${version}/SHA256SUMS`;
 };
 
-// is mutagen installed
-export const isMutagenInstalled = async (): Promise<boolean> => {
-	const mutagenPath = getMutagenPath();
-	if (!existsSync(mutagenPath)) {
-		return false;
-	}
-
-	try {
-		await execa(mutagenPath, ["version"]);
-		return true;
-	} catch {
-		return false;
-	}
-};
-
-// get installed mutagen version
-export const getInstalledMutagenVersion = async (): Promise<string | null> => {
+const probeInstalledMutagenVersion = async (): Promise<string | null> => {
 	const mutagenPath = getMutagenPath();
 	if (!existsSync(mutagenPath)) return null;
+
 	try {
 		const result = await execa(mutagenPath, ["version"]);
 		return result.stdout.trim();
 	} catch {
 		return null;
 	}
+};
+
+// is mutagen installed
+export const isMutagenInstalled = async (): Promise<boolean> => {
+	return (await probeInstalledMutagenVersion()) !== null;
+};
+
+// get installed mutagen version
+export const getInstalledMutagenVersion = async (): Promise<string | null> => {
+	return probeInstalledMutagenVersion();
 };
 
 // download and install the Mutagen binary with checksum verification

--- a/src/lib/errors.ts
+++ b/src/lib/errors.ts
@@ -1,4 +1,5 @@
 // error handling utilities: safe message extraction and type guards.
+import type { ExecaLikeError } from "@typedefs/index.ts";
 
 // safely extract an error message from an unknown error type.
 // use this in catch blocks for general errors.
@@ -31,15 +32,6 @@ export const getExecaErrorMessage = (error: unknown): string => {
 	}
 	return "Unknown error";
 };
-
-// type for execa-like errors with common properties.
-export interface ExecaLikeError {
-	exitCode?: number;
-	stderr?: string;
-	stdout?: string;
-	command?: string;
-	message?: string;
-}
 
 // type guard to check if an error is an execa-like error.
 // narrows the type for safe property access.

--- a/src/lib/mutagen-platform.ts
+++ b/src/lib/mutagen-platform.ts
@@ -1,8 +1,4 @@
-export interface MutagenPlatformInfo {
-	os: "darwin" | "linux";
-	cpu: "arm64" | "amd64";
-	filename: string;
-}
+import type { MutagenPlatformInfo } from "@typedefs/index.ts";
 
 // normalize platform/arch into mutagen release naming components.
 export const getMutagenPlatformInfo = (

--- a/src/lib/project.ts
+++ b/src/lib/project.ts
@@ -26,8 +26,9 @@ export const resolveProjectFromCwd = (): string | null => {
 
 	const rel = relative(realProjectsDir, realCwd);
 
-	// If relative path starts with "..", we're not in PROJECTS_DIR
-	if (rel.startsWith("..") || rel === cwd) {
+	// If relative path starts with "..", we're not in PROJECTS_DIR.
+	// rel === "" means cwd is the projects root itself, not a project.
+	if (rel.startsWith("..") || rel === "") {
 		return null;
 	}
 

--- a/src/lib/remote-encryption.ts
+++ b/src/lib/remote-encryption.ts
@@ -2,6 +2,7 @@ import { mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { decryptFile, encryptFile } from "@lib/encryption.ts";
+import { runRemotePathTest } from "@lib/remote.ts";
 import { escapeRemotePath, escapeShellArg } from "@lib/shell.ts";
 import { runRemoteCommand, secureScp } from "@lib/ssh.ts";
 
@@ -62,11 +63,7 @@ export const createRemoteArchiveTarget = (
 export const remoteArchiveExists = async (
 	target: RemoteArchiveTarget,
 ): Promise<boolean> => {
-	const checkResult = await runRemoteCommand(
-		target.host,
-		`test -f ${escapeRemotePath(target.remoteArchivePath)} && echo "EXISTS" || echo "NOT_FOUND"`,
-	);
-	return checkResult.success && checkResult.stdout?.includes("EXISTS") === true;
+	return runRemotePathTest(target.host, target.remoteArchivePath, "-f");
 };
 
 // decrypt remote archive

--- a/src/lib/remote.ts
+++ b/src/lib/remote.ts
@@ -4,6 +4,19 @@ import { escapeRemotePath } from "@lib/shell.ts";
 import { runRemoteCommand } from "@lib/ssh.ts";
 import { validateRemoteProjectPath } from "@lib/validation.ts";
 
+// run a remote shell test (-d/-f) for a path and return whether it exists.
+export const runRemotePathTest = async (
+	host: string,
+	path: string,
+	testFlag: "-d" | "-f",
+): Promise<boolean> => {
+	const result = await runRemoteCommand(
+		host,
+		`test ${testFlag} ${escapeRemotePath(path)} && echo "EXISTS" || echo "NOT_FOUND"`,
+	);
+	return result.success && result.stdout?.includes("EXISTS") === true;
+};
+
 // check if a project directory exists on the remote server.
 export const checkRemoteProjectExists = async (
 	host: string,
@@ -15,9 +28,5 @@ export const checkRemoteProjectExists = async (
 		return false;
 	}
 	const fullPath = `${basePath}/${project}`;
-	const result = await runRemoteCommand(
-		host,
-		`test -d ${escapeRemotePath(fullPath)} && echo "EXISTS" || echo "NOT_FOUND"`,
-	);
-	return result.stdout?.includes("EXISTS") ?? false;
+	return runRemotePathTest(host, fullPath, "-d");
 };

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -371,6 +371,15 @@ export interface SessionConflictResult {
 	existingSession?: SessionInfo;
 }
 
+// Mutagen types
+
+// normalized platform/arch identifiers used for Mutagen release assets.
+export interface MutagenPlatformInfo {
+	os: "darwin" | "linux";
+	cpu: "arm64" | "amd64";
+	filename: string;
+}
+
 // Validation types
 
 // result of input validation functions. Discriminated union for type safety.
@@ -398,6 +407,17 @@ export interface UpdateCheckMetadata {
 	lastCheck: string; // ISO 8601 datetime of last check
 	latestVersion: string | null; // Latest version found, or null if check failed
 	latestStableVersion: string | null; // Latest non-prerelease version
+}
+
+// Error types
+
+// execa-like errors with commonly inspected process fields.
+export interface ExecaLikeError {
+	exitCode?: number;
+	stderr?: string;
+	stdout?: string;
+	command?: string;
+	message?: string;
 }
 
 // Audit types

--- a/tests/unit/commands/encrypt.test.ts
+++ b/tests/unit/commands/encrypt.test.ts
@@ -1,27 +1,8 @@
-import { afterEach, beforeEach, describe, expect, test } from "bun:test";
-import { mkdirSync, rmSync } from "node:fs";
-import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { describe, expect, test } from "bun:test";
+import { setupTestContext } from "@tests/helpers/test-utils.ts";
 
 describe("encrypt command", () => {
-	let testDir: string;
-	let originalEnv: string | undefined;
-
-	beforeEach(() => {
-		testDir = join(tmpdir(), `skybox-encrypt-test-${Date.now()}`);
-		mkdirSync(testDir, { recursive: true });
-		originalEnv = process.env.SKYBOX_HOME;
-		process.env.SKYBOX_HOME = testDir;
-	});
-
-	afterEach(() => {
-		rmSync(testDir, { recursive: true, force: true });
-		if (originalEnv) {
-			process.env.SKYBOX_HOME = originalEnv;
-		} else {
-			delete process.env.SKYBOX_HOME;
-		}
-	});
+	setupTestContext("encrypt");
 
 	test("encrypt command module exports encryptCommand", async () => {
 		const mod = await import("@commands/encrypt.ts");

--- a/tests/unit/commands/init-permissions.test.ts
+++ b/tests/unit/commands/init-permissions.test.ts
@@ -1,42 +1,35 @@
-import { afterEach, beforeEach, describe, expect, test } from "bun:test";
-import { rmSync, statSync } from "node:fs";
-import { tmpdir } from "node:os";
+import { describe, expect, test } from "bun:test";
+import { statSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { saveConfig } from "@lib/config.ts";
 import { getConfigPath } from "@lib/paths.ts";
-import { createTestConfig } from "@tests/helpers/test-utils.ts";
+import {
+	createTestConfig,
+	setupTestContext,
+} from "@tests/helpers/test-utils.ts";
 
 describe("init directory permissions", () => {
-	let testDir: string;
-	let originalEnv: string | undefined;
+	const getCtx = setupTestContext("init-permissions");
 
-	beforeEach(() => {
-		// Point SKYBOX_HOME to a non-existent directory so saveConfig creates it fresh
-		testDir = join(tmpdir(), `skybox-init-perms-test-${Date.now()}`);
-		originalEnv = process.env.SKYBOX_HOME;
-		process.env.SKYBOX_HOME = testDir;
-	});
-
-	afterEach(() => {
-		rmSync(testDir, { recursive: true, force: true });
-		if (originalEnv) {
-			process.env.SKYBOX_HOME = originalEnv;
-		} else {
-			delete process.env.SKYBOX_HOME;
-		}
-	});
+	const useFreshHome = (): string => {
+		const freshHome = join(getCtx().testDir, "fresh-home");
+		process.env.SKYBOX_HOME = freshHome;
+		return freshHome;
+	};
 
 	test("saveConfig creates config directory with mode 0o700", () => {
+		const freshHome = useFreshHome();
 		const config = createTestConfig();
 		saveConfig(config);
 
-		const configDir = dirname(getConfigPath());
+		const configDir = dirname(join(freshHome, "config.yaml"));
 		const stats = statSync(configDir);
 		const mode = stats.mode & 0o777;
 		expect(mode).toBe(0o700);
 	});
 
 	test("saveConfig creates config file with mode 0o600", () => {
+		useFreshHome();
 		const config = createTestConfig();
 		saveConfig(config);
 


### PR DESCRIPTION
## Summary
- simplify duplicated config/remote/ssh/container/template helper logic without behavior changes
- add shared atomic write helper and reuse it for config/session persistence
- centralize reusable types (`MutagenPlatformInfo`, `ExecaLikeError`) in `src/types/index.ts`
- reduce repeated SKYBOX_HOME test setup by reusing shared test context helpers

## Validation
- bun run check:ci
- bun run typecheck
- bun run test
