### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,5 +1,8 @@
 name: E2E Tests
 
+permissions:
+  contents: read
+
 on:
   schedule:
     # Run nightly at 2 AM UTC


### PR DESCRIPTION
Potential fix for [https://github.com/NoorXLabs/SkyBox/security/code-scanning/3](https://github.com/NoorXLabs/SkyBox/security/code-scanning/3)

In general, the fix is to add an explicit `permissions` block to the workflow or to the individual job, specifying the least privileges required. Since this job only needs to read the repository contents (for `actions/checkout`) and does not appear to require any write operations to the repository or other privileged scopes, it is safe to set `contents: read` as the only permission. Adding this at the workflow root will apply to all jobs, but here there is only one job (`e2e`), so either placement is fine; following the recommendation, we’ll add it at the workflow root so it is clearly documented and applies by default.

Concretely, in `.github/workflows/e2e.yml`, insert a `permissions` block near the top, alongside `name:` and `on:`. For example, between the `name: E2E Tests` line and the `on:` section, add:

```yaml
permissions:
  contents: read
```

This does not require any imports or additional definitions, and it will ensure the GITHUB_TOKEN exposed to `actions/checkout@v6` (and future steps that might use it) is restricted to read-only access to repository contents. No functional behaviour of the tests or SSH operations is changed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
